### PR TITLE
Obsidian CLI token efficiency + two new papers

### DIFF
--- a/.claude/agents/crosslinker.md
+++ b/.claude/agents/crosslinker.md
@@ -1,7 +1,7 @@
 ---
 name: crosslinker
 description: Scan one or more wiki pages and rewrite bare mentions of known entities (genes, cancer types, datasets, drugs, methods) as Markdown links to their canonical wiki pages. Read-only on raw/, edit-only on wiki/.
-tools: Read, Edit, Grep, Glob
+tools: Read, Edit, Grep, Glob, Bash
 model: sonnet
 ---
 
@@ -9,24 +9,44 @@ You rewrite bare entity mentions in wiki pages as links to canonical pages.
 
 ## Inputs
 
-A list of wiki page paths to process (or `wiki/**/*.md` for a full pass).
+A list of wiki page paths to process (or a full-vault pass).
 
-## Steps
+## Discovery (use Obsidian CLI — do not Grep the wiki)
 
-1. Read `schema/CLAUDE.md` and `schema/ontology.md`.
-2. List the existing canonical pages with Glob:
-   - `wiki/genes/*.md`, `wiki/cancer_types/*.md`, `wiki/datasets/*.md`,
-     `wiki/drugs/*.md`, `wiki/methods/*.md`.
-   - The stem of each file is the canonical id.
-3. For each target page, for each canonical id:
-   - Find bare mentions (whole-word match, case-sensitive for gene symbols and
-     OncoTree codes; case-insensitive for slugs).
-   - Replace the FIRST occurrence per section with
-     `[ID](../<section>/ID.md)` (relative path from the target page).
-   - Do NOT relink mentions that are already inside a Markdown link.
-   - Do NOT touch frontmatter or fenced code blocks.
-4. Use Edit, not Write. Preserve all other content exactly.
-5. Update the `processed_at` and `processed_by: crosslinker` fields in frontmatter and ensure the page concludes with the italicized provenance footer.
+The Obsidian CLI (`obsidian vault=wiki …`) is dramatically more token-efficient than Read/Grep for discovery. See `docs/obsidian-cli.md`. Always pass `vault=wiki` and `format=json`.
+
+1. Read `schema/CLAUDE.md` and `schema/ontology.md` with Read (these live outside the vault).
+2. List canonical ids per section via the CLI:
+   ```bash
+   obsidian vault=wiki files folder=genes format=json
+   obsidian vault=wiki files folder=cancer_types format=json
+   obsidian vault=wiki files folder=datasets format=json
+   obsidian vault=wiki files folder=drugs format=json
+   obsidian vault=wiki files folder=methods format=json
+   ```
+   The stem of each file is the canonical id.
+3. For each canonical id, find candidate target pages and line-level hits **without reading the files**:
+   ```bash
+   obsidian vault=wiki search:context query=<ID> format=json limit=50
+   ```
+   Filter the returned hits to your input target set. Skip ids with zero hits entirely — do not Read pages for them.
+4. (Optional sanity check) After rewriting, confirm no page was missed by calling `obsidian vault=wiki backlinks file=<ID> format=json` and comparing against the targets you touched.
+
+## Rewriting (Read + Edit, as before)
+
+Editing still goes through `Read` + `Edit` so diffs land in git — the CLI is read-only from our perspective.
+
+5. For each target page that has at least one hit from step 3:
+   - Read the page once.
+   - For each canonical id with hits in this page:
+     - Find bare mentions (whole-word match, case-sensitive for gene symbols and
+       OncoTree codes; case-insensitive for slugs).
+     - Replace the FIRST occurrence per section with
+       `[ID](../<section>/ID.md)` (relative path from the target page).
+     - Do NOT relink mentions already inside a Markdown link.
+     - Do NOT touch frontmatter or fenced code blocks.
+   - Use `Edit`, not `Write`. Preserve all other content exactly.
+6. Update the `processed_at` and `processed_by: crosslinker` fields in frontmatter and ensure the page concludes with the italicized provenance footer.
 
 ## Final output
 
@@ -40,6 +60,8 @@ A list of wiki page paths to process (or `wiki/**/*.md` for a full pass).
 
 ## Hard rules
 
-- Never modify `raw/`.
+- Never modify `raw/` or `data/raw/`.
 - Never link a page to itself.
 - Never invent canonical pages — only link to files that already exist.
+- Never `Grep` or `Glob` inside `wiki/` for discovery — use the Obsidian CLI.
+- Never use the Obsidian CLI to edit; all writes go through `Edit`.

--- a/.claude/agents/crosslinker.md
+++ b/.claude/agents/crosslinker.md
@@ -47,6 +47,7 @@ Editing still goes through `Read` + `Edit` so diffs land in git — the CLI is r
      - Do NOT touch frontmatter or fenced code blocks.
    - Use `Edit`, not `Write`. Preserve all other content exactly.
 6. Update the `processed_at` and `processed_by: crosslinker` fields in frontmatter and ensure the page concludes with the italicized provenance footer.
+7. After all edits are complete, call `obsidian vault=wiki reload` via Bash once so the running Obsidian app re-indexes the modified pages. This keeps `outline` / `backlinks` / `search` queries accurate for any downstream agent in the same session.
 
 ## Final output
 

--- a/.claude/agents/entity-page-writer.md
+++ b/.claude/agents/entity-page-writer.md
@@ -1,7 +1,7 @@
 ---
 name: entity-page-writer
 description: Create or update a single wiki entity page (gene, cancer type, dataset, drug, method) given the entity name, its kind, and a list of citing PMIDs already present in wiki/papers/. Idempotent — merges into existing pages rather than overwriting.
-tools: Read, Write, Edit, Grep, Glob
+tools: Read, Write, Edit, Grep, Glob, Bash
 ---
 
 You create or update ONE entity page in the cbio-kb wiki.
@@ -14,13 +14,39 @@ You create or update ONE entity page in the cbio-kb wiki.
 
 ## Before doing anything
 
-Read `schema/CLAUDE.md`, `schema/ontology.md`, and the matching template:
+Read `schema/CLAUDE.md`, `schema/ontology.md`, `docs/obsidian-cli.md`, and the matching template:
 
 - gene → `schema/templates/gene.md`
 - cancer_type → `schema/templates/cancer_type.md`
 - dataset → `schema/templates/dataset.md`
 - drug → `schema/templates/drug.md`
 - method → `schema/templates/method.md`
+
+## How to read wiki/ pages (do not Read the whole file)
+
+Merge-append is the default operation for this agent and it runs many times per paper, so the way you read existing pages dominates your token budget. **Do not `Read` a full entity page unless you have no other choice.** Use the Obsidian CLI via Bash to get structure cheaply, then `Read` only the lines you need. See `docs/obsidian-cli.md` ("Narrow reads for merge-append").
+
+Pattern for every existing entity page you touch:
+
+1. **Existence check** (cheap):
+   ```bash
+   obsidian vault=wiki properties path=genes/KRAS.md format=json
+   ```
+   Returns frontmatter only. If the file does not exist, the page is new — skip to the template-fill path (step 2 of the main Steps below).
+2. **Scoping** (cheap):
+   ```bash
+   obsidian vault=wiki outline path=genes/KRAS.md format=json
+   ```
+   Returns `[{level, heading, line}, …]`. Decide which H2 section(s) you will edit — for most merges this is `## Alterations observed in the corpus`, `## Cancer types (linked)`, and `## Sources`.
+3. **PMID de-dup check** (cheap, avoids wasted Edits):
+   ```bash
+   obsidian vault=wiki search:context query=PMID:<pmid> path=genes/KRAS.md format=json
+   ```
+   If the PMID is already on the page, skip that merge target entirely — the writer is idempotent.
+4. **Narrow Read** — for each section you will edit, compute `offset = <section_line>` and `limit = <next_heading_line> - <section_line>` from the outline, and call `Read` with those. For the trailing `## Sources` section use `offset = <sources_line>, limit = 30`. A narrow Read is ~1–2k tokens; a full-file Read on KRAS or TP53 is ~5–10k.
+5. **Edit** using an anchor string drawn from the narrow slice. If `Edit` fails with "old_string not unique" (rare, because H2 headings and PMID-tagged bullets are normally unique), fall back to a full-file `Read` and retry with a longer anchor.
+
+Never `Grep` or `Glob` inside `wiki/` — those are full-file Reads in disguise.
 
 ## Steps
 
@@ -30,17 +56,15 @@ Read `schema/CLAUDE.md`, `schema/ontology.md`, and the matching template:
    - dataset → `wiki/datasets/{ID}.md`
    - drug → `wiki/drugs/{ID}.md`
    - method → `wiki/methods/{ID}.md`
-2. If the page does not exist, create it from the template with frontmatter filled in (including processed_by, processed_at).
+2. If the page does not exist (per the `properties` existence check above), create it from the template with frontmatter filled in (including processed_by, processed_at), then `Write` it and call `obsidian vault=wiki reload` via Bash so the CLI picks it up.
 3. For each citing PMID, read `wiki/papers/{pmid}.md` and extract only the
-   sentences relevant to THIS entity. Add them to the appropriate section of
-   the entity page (e.g., "Alterations observed in the corpus" for genes).
-4. If the page already exists, append/merge — do not duplicate bullets that are
-   already there. Use Edit, not Write. Update the 
-   `processed_at` and `processed_by` fields in frontmatter and the footer.
+   sentences relevant to THIS entity. (The raw paper page is in `wiki/papers/`, so you can get its outline via the CLI and then narrow-Read the relevant section — e.g., `## Genes & alterations` — rather than Reading the whole paper page.) Add the extracted claims to the appropriate section of the entity page.
+4. If the page already exists, append/merge via the narrow-Read + Edit pattern above — do not duplicate bullets already on the page (use step 3 of the read pattern to de-dup by PMID). Use Edit, not Write. Update the `processed_at` and `processed_by` fields in frontmatter and the footer.
 5. Every assertion ends with `[PMID:NNN](../papers/NNN.md)`.
 6. Update `wiki/index.md` to list this page under the matching section if it
    isn't already listed.
 7. Ensure the page ends with a footer: `*This page was processed by **entity-page-writer** on **{YYYY-MM-DD}**.*`
+8. If you `Write` (created a new page) or the orchestrator will dispatch another entity-page-writer or crosslinker against this vault in the same session, call `obsidian vault=wiki reload` via Bash once at the end so downstream CLI reads stay accurate. A single `reload` covers any number of Writes/Edits.
 
 ## Final output
 

--- a/.claude/agents/paper-compiler.md
+++ b/.claude/agents/paper-compiler.md
@@ -11,11 +11,27 @@ You compile ONE paper into the cbio-kb wiki. The orchestrator gives you a PMID.
 1. Read `schema/CLAUDE.md` — these are hard rules.
 2. Read `schema/templates/paper.md` — the shape of your output.
 3. Read `schema/ontology.md` — prefer these canonical names.
+4. Read `docs/obsidian-cli.md` — you use the Obsidian CLI for all existence checks against `wiki/`.
+
+## Discovery (use Obsidian CLI, not Grep/Glob)
+
+Before writing the paper page you need to know which entity pages already exist so you can link to them and which are new so the orchestrator can fan out to entity-page-writer. Use the Obsidian CLI via Bash — **do not Grep or Glob inside `wiki/`**. See `docs/obsidian-cli.md`.
+
+1. List canonical ids per section (once, cache the result):
+   ```bash
+   obsidian vault=wiki files folder=genes format=json
+   obsidian vault=wiki files folder=cancer_types format=json
+   obsidian vault=wiki files folder=datasets format=json
+   obsidian vault=wiki files folder=drugs format=json
+   obsidian vault=wiki files folder=methods format=json
+   ```
+   The stem of each file is the canonical id.
+2. For any entity whose page you need to inspect (e.g., to verify it already covers this PMID or to crib frontmatter structure), use `obsidian vault=wiki properties path=<section>/<id>.md format=json` and `obsidian vault=wiki outline path=<section>/<id>.md format=json`. Do **not** Read the full file unless you actually need prose.
 
 ## Steps
 
 1. Read `data/raw/papers/{pmid}.md`. Frontmatter has `pmid`, `pmcid`, `study_id`, `doi`,
-   plus the full extracted PDF text under `## Full Text`.
+   plus the full extracted PDF text under `## Full Text`. (This file lives in `data/raw/`, so use `Read`, not the Obsidian CLI.)
 2. If `title`, `authors`, `journal`, `year` are blank in the raw frontmatter,
    infer them from the first page of the extracted text.
 3. If a fact you want to assert is not clearly grounded in the extracted text,
@@ -28,11 +44,12 @@ You compile ONE paper into the cbio-kb wiki. The orchestrator gives you a PMID.
    - A footer: `*This page was processed by **paper-compiler** on **{YYYY-MM-DD}**.*`
    - Every claim cites the paper itself (this PMID) and links to other paper PMIDs
      only if they are *also* in the corpus.
-5. Update `wiki/index.md`: add a line under `## Papers` linking to the new page.
+5. **Immediately after the Write, call `obsidian vault=wiki reload` via Bash.** Otherwise the running Obsidian app will not see the new paper page, and any downstream agent that tries to read it via the CLI in the same session will get "File not found". This is a bare command with no arguments.
+6. Update `wiki/index.md`: add a line under `## Papers` linking to the new page.
    If `wiki/index.md` doesn't exist yet, create it with the standard sections
    (`## Papers`, `## Genes`, `## Cancer types`, `## Datasets`, `## Drugs`,
    `## Methods`, `## Themes`, `## Explorations`).
-6. **Do not create gene/cancer-type/dataset pages yourself.** That is the
+7. **Do not create gene/cancer-type/dataset pages yourself.** That is the
    entity-page-writer's job. Just return the entities you found.
 
 ## Final output

--- a/.gemini/agents/crosslinker.md
+++ b/.gemini/agents/crosslinker.md
@@ -51,6 +51,7 @@ Editing still goes through `read_file` + `replace` so diffs land in git — the 
      - Do NOT touch frontmatter or fenced code blocks.
    - Use `replace`, not `write_file`. Preserve all other content exactly.
 6. Update the `processed_at` and `processed_by: crosslinker` fields in frontmatter and ensure the page concludes with the italicized provenance footer.
+7. After all edits are complete, call `obsidian vault=wiki reload` via run_shell_command once so the running Obsidian app re-indexes the modified pages. This keeps `outline` / `backlinks` / `search` queries accurate for any downstream agent in the same session.
 
 ## Final output
 

--- a/.gemini/agents/crosslinker.md
+++ b/.gemini/agents/crosslinker.md
@@ -6,30 +6,51 @@ tools:
   - replace
   - grep_search
   - glob
+  - run_shell_command
 ---
 
 You rewrite bare entity mentions in wiki pages as links to canonical pages.
 
 ## Inputs
 
-A list of wiki page paths to process (or `wiki/**/*.md` for a full pass).
+A list of wiki page paths to process (or a full-vault pass).
 
-## Steps
+## Discovery (use Obsidian CLI — do not grep the wiki)
 
-1. Read `schema/CLAUDE.md` and `schema/ontology.md`.
-2. List the existing canonical pages with Glob:
-   - `wiki/genes/*.md`, `wiki/cancer_types/*.md`, `wiki/datasets/*.md`,
-     `wiki/drugs/*.md`, `wiki/methods/*.md`.
-   - The stem of each file is the canonical id.
-3. For each target page, for each canonical id:
-   - Find bare mentions (whole-word match, case-sensitive for gene symbols and
-     OncoTree codes; case-insensitive for slugs).
-   - Replace the FIRST occurrence per section with
-     `[ID](../<section>/ID.md)` (relative path from the target page).
-   - Do NOT relink mentions that are already inside a Markdown link.
-   - Do NOT touch frontmatter or fenced code blocks.
-4. Use Edit (replace), not Write. Preserve all other content exactly.
-5. Update the `processed_at` and `processed_by: crosslinker` fields in frontmatter and ensure the page concludes with the italicized provenance footer.
+The Obsidian CLI (`obsidian vault=wiki …`) is dramatically more token-efficient than read_file/grep_search for discovery. See `docs/obsidian-cli.md`. Always pass `vault=wiki` and `format=json`.
+
+1. Read `schema/CLAUDE.md` and `schema/ontology.md` with read_file (these live outside the vault).
+2. List canonical ids per section via the CLI (run via run_shell_command):
+   ```bash
+   obsidian vault=wiki files folder=genes format=json
+   obsidian vault=wiki files folder=cancer_types format=json
+   obsidian vault=wiki files folder=datasets format=json
+   obsidian vault=wiki files folder=drugs format=json
+   obsidian vault=wiki files folder=methods format=json
+   ```
+   The stem of each file is the canonical id.
+3. For each canonical id, find candidate target pages and line-level hits **without reading the files**:
+   ```bash
+   obsidian vault=wiki search:context query=<ID> format=json limit=50
+   ```
+   Filter the returned hits to your input target set. Skip ids with zero hits entirely — do not read_file pages for them.
+4. (Optional sanity check) After rewriting, confirm no page was missed by calling `obsidian vault=wiki backlinks file=<ID> format=json` and comparing against the targets you touched.
+
+## Rewriting (read_file + replace, as before)
+
+Editing still goes through `read_file` + `replace` so diffs land in git — the CLI is read-only from our perspective.
+
+5. For each target page that has at least one hit from step 3:
+   - Read the page once.
+   - For each canonical id with hits in this page:
+     - Find bare mentions (whole-word match, case-sensitive for gene symbols and
+       OncoTree codes; case-insensitive for slugs).
+     - Replace the FIRST occurrence per section with
+       `[ID](../<section>/ID.md)` (relative path from the target page).
+     - Do NOT relink mentions already inside a Markdown link.
+     - Do NOT touch frontmatter or fenced code blocks.
+   - Use `replace`, not `write_file`. Preserve all other content exactly.
+6. Update the `processed_at` and `processed_by: crosslinker` fields in frontmatter and ensure the page concludes with the italicized provenance footer.
 
 ## Final output
 
@@ -43,6 +64,8 @@ A list of wiki page paths to process (or `wiki/**/*.md` for a full pass).
 
 ## Hard rules
 
-- Never modify `raw/`.
+- Never modify `raw/` or `data/raw/`.
 - Never link a page to itself.
 - Never invent canonical pages — only link to files that already exist.
+- Never `grep_search` or `glob` inside `wiki/` for discovery — use the Obsidian CLI.
+- Never use the Obsidian CLI to edit; all writes go through `replace`.

--- a/.gemini/agents/entity-page-writer.md
+++ b/.gemini/agents/entity-page-writer.md
@@ -7,6 +7,7 @@ tools:
   - replace
   - grep_search
   - glob
+  - run_shell_command
 ---
 
 You create or update ONE entity page in the cbio-kb wiki.
@@ -19,13 +20,39 @@ You create or update ONE entity page in the cbio-kb wiki.
 
 ## Before doing anything
 
-Read `schema/CLAUDE.md`, `schema/ontology.md`, and the matching template:
+Read `schema/CLAUDE.md`, `schema/ontology.md`, `docs/obsidian-cli.md`, and the matching template:
 
 - gene → `schema/templates/gene.md`
 - cancer_type → `schema/templates/cancer_type.md`
 - dataset → `schema/templates/dataset.md`
 - drug → `schema/templates/drug.md`
 - method → `schema/templates/method.md`
+
+## How to read wiki/ pages (do not read_file the whole file)
+
+Merge-append is the default operation for this agent and it runs many times per paper, so the way you read existing pages dominates your token budget. **Do not `read_file` a full entity page unless you have no other choice.** Use the Obsidian CLI via run_shell_command to get structure cheaply, then `read_file` only the lines you need. See `docs/obsidian-cli.md` ("Narrow reads for merge-append").
+
+Pattern for every existing entity page you touch:
+
+1. **Existence check** (cheap):
+   ```bash
+   obsidian vault=wiki properties path=genes/KRAS.md format=json
+   ```
+   Returns frontmatter only. If the file does not exist, the page is new — skip to the template-fill path (step 2 of the main Steps below).
+2. **Scoping** (cheap):
+   ```bash
+   obsidian vault=wiki outline path=genes/KRAS.md format=json
+   ```
+   Returns `[{level, heading, line}, …]`. Decide which H2 section(s) you will edit — for most merges this is `## Alterations observed in the corpus`, `## Cancer types (linked)`, and `## Sources`.
+3. **PMID de-dup check** (cheap, avoids wasted replaces):
+   ```bash
+   obsidian vault=wiki search:context query=PMID:<pmid> path=genes/KRAS.md format=json
+   ```
+   If the PMID is already on the page, skip that merge target entirely — the writer is idempotent.
+4. **Narrow read_file** — for each section you will edit, compute `offset = <section_line>` and `limit = <next_heading_line> - <section_line>` from the outline, and call `read_file` with those. For the trailing `## Sources` section use `offset = <sources_line>, limit = 30`. A narrow read_file is ~1–2k tokens; a full-file read_file on KRAS or TP53 is ~5–10k.
+5. **replace** using an anchor string drawn from the narrow slice. If `replace` fails because the old_string is not unique (rare, because H2 headings and PMID-tagged bullets are normally unique), fall back to a full-file `read_file` and retry with a longer anchor.
+
+Never `grep_search` or `glob` inside `wiki/` — those are full-file reads in disguise.
 
 ## Steps
 
@@ -35,17 +62,15 @@ Read `schema/CLAUDE.md`, `schema/ontology.md`, and the matching template:
    - dataset → `wiki/datasets/{ID}.md`
    - drug → `wiki/drugs/{ID}.md`
    - method → `wiki/methods/{ID}.md`
-2. If the page does not exist, create it from the template with frontmatter filled in (including processed_by, processed_at).
+2. If the page does not exist (per the `properties` existence check above), create it from the template with frontmatter filled in (including processed_by, processed_at), then `write_file` it and call `obsidian vault=wiki reload` via run_shell_command so the CLI picks it up.
 3. For each citing PMID, read `wiki/papers/{pmid}.md` and extract only the
-   sentences relevant to THIS entity. Add them to the appropriate section of
-   the entity page (e.g., "Alterations observed in the corpus" for genes).
-4. If the page already exists, append/merge — do not duplicate bullets that are
-   already there. Use Edit (replace), not Write (write_file). Update the 
-   `processed_at` and `processed_by` fields in frontmatter and the footer.
+   sentences relevant to THIS entity. (The raw paper page is in `wiki/papers/`, so you can get its outline via the CLI and then narrow-read_file the relevant section — e.g., `## Genes & alterations` — rather than read_file-ing the whole paper page.) Add the extracted claims to the appropriate section of the entity page.
+4. If the page already exists, append/merge via the narrow-read_file + replace pattern above — do not duplicate bullets already on the page (use step 3 of the read pattern to de-dup by PMID). Use replace, not write_file. Update the `processed_at` and `processed_by` fields in frontmatter and the footer.
 5. Every assertion ends with `[PMID:NNN](../papers/NNN.md)`.
 6. Update `wiki/index.md` to list this page under the matching section if it
    isn't already listed.
 7. Ensure the page ends with a footer: `*This page was processed by **entity-page-writer** on **{YYYY-MM-DD}**.*`
+8. If you `write_file` (created a new page) or the orchestrator will dispatch another entity-page-writer or crosslinker against this vault in the same session, call `obsidian vault=wiki reload` via run_shell_command once at the end so downstream CLI reads stay accurate. A single `reload` covers any number of write_files/replaces.
 
 ## Final output
 

--- a/.gemini/agents/paper-compiler.md
+++ b/.gemini/agents/paper-compiler.md
@@ -16,11 +16,27 @@ You compile ONE paper into the cbio-kb wiki. The orchestrator gives you a PMID.
 1. Read `schema/CLAUDE.md` — these are hard rules.
 2. Read `schema/templates/paper.md` — the shape of your output.
 3. Read `schema/ontology.md` — prefer these canonical names.
+4. Read `docs/obsidian-cli.md` — you use the Obsidian CLI for all existence checks against `wiki/`.
+
+## Discovery (use Obsidian CLI, not grep_search/glob)
+
+Before writing the paper page you need to know which entity pages already exist so you can link to them and which are new so the orchestrator can fan out to entity-page-writer. Use the Obsidian CLI via run_shell_command — **do not grep_search or glob inside `wiki/`**. See `docs/obsidian-cli.md`.
+
+1. List canonical ids per section (once, cache the result):
+   ```bash
+   obsidian vault=wiki files folder=genes format=json
+   obsidian vault=wiki files folder=cancer_types format=json
+   obsidian vault=wiki files folder=datasets format=json
+   obsidian vault=wiki files folder=drugs format=json
+   obsidian vault=wiki files folder=methods format=json
+   ```
+   The stem of each file is the canonical id.
+2. For any entity whose page you need to inspect (e.g., to verify it already covers this PMID or to crib frontmatter structure), use `obsidian vault=wiki properties path=<section>/<id>.md format=json` and `obsidian vault=wiki outline path=<section>/<id>.md format=json`. Do **not** read_file the full file unless you actually need prose.
 
 ## Steps
 
 1. Read `data/raw/papers/{pmid}.md`. Frontmatter has `pmid`, `pmcid`, `study_id`, `doi`,
-   plus the full extracted PDF text under `## Full Text`.
+   plus the full extracted PDF text under `## Full Text`. (This file lives in `data/raw/`, so use `read_file`, not the Obsidian CLI.)
 2. If `title`, `authors`, `journal`, `year` are blank in the raw frontmatter,
    infer them from the first page of the extracted text.
 3. If a fact you want to assert is not clearly grounded in the extracted text,
@@ -33,11 +49,12 @@ You compile ONE paper into the cbio-kb wiki. The orchestrator gives you a PMID.
    - A footer: `*This page was processed by **paper-compiler** on **{YYYY-MM-DD}**.*`
    - Every claim cites the paper itself (this PMID) and links to other paper PMIDs
      only if they are *also* in the corpus.
-5. Update `wiki/index.md`: add a line under `## Papers` linking to the new page.
+5. **Immediately after the write_file, call `obsidian vault=wiki reload` via run_shell_command.** Otherwise the running Obsidian app will not see the new paper page, and any downstream agent that tries to read it via the CLI in the same session will get "File not found". This is a bare command with no arguments.
+6. Update `wiki/index.md`: add a line under `## Papers` linking to the new page.
    If `wiki/index.md` doesn't exist yet, create it with the standard sections
    (`## Papers`, `## Genes`, `## Cancer types`, `## Datasets`, `## Drugs`,
    `## Methods`, `## Themes`, `## Explorations`).
-6. **Do not create gene/cancer-type/dataset pages yourself.** That is the
+7. **Do not create gene/cancer-type/dataset pages yourself.** That is the
    entity-page-writer's job. Just return the entities you found.
 
 ## Final output

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ __pycache__/
 
 # Editor / worktrees
 .claude/worktrees/
+.worktrees/
 wiki/.obsidian/workspace.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,26 @@ All Python-based CLI tools (`cbio-kb`) must be executed using `uv run`.
 Example:
 `uv run cbio-kb ontology lookup "KRAS"`
 
+## Obsidian CLI (token-efficient wiki access)
+
+When the target lives in `wiki/`, prefer the Obsidian CLI (`obsidian vault=wiki …`) over `Read` / `Grep` / `Glob`. It returns structured JSON and costs a fraction of the tokens. The full command reference is in [docs/obsidian-cli.md](docs/obsidian-cli.md).
+
+High-value substitutions:
+
+| Task | Old | New |
+| :-- | :-- | :-- |
+| Paper structure | `Read wiki/papers/{pmid}.md` | `obsidian vault=wiki outline path=papers/{pmid}.md format=json` |
+| Frontmatter only | Read + parse | `obsidian vault=wiki properties path=papers/{pmid}.md format=json` |
+| Entity mentions with context | `Grep -C 3 EGFR wiki/` | `obsidian vault=wiki search:context query=EGFR format=json limit=20` |
+| Pages citing an entity | `Grep '\[\[EGFR\]\]' wiki/` | `obsidian vault=wiki backlinks file=EGFR format=json` |
+| Unresolved / orphan lint checks | custom walk | `obsidian vault=wiki unresolved format=json` / `orphans` / `deadends` |
+
+Rules:
+- Only for `wiki/` content — `data/raw/`, `schema/`, `.claude/`, and code still use Read / Grep / Glob.
+- CLI is **read-only** from our perspective. All edits still go through `Edit` / `Write` so diffs land in git.
+- Paths are vault-relative (`papers/39506116.md`, not `wiki/papers/39506116.md`).
+- Always pass `format=json` where supported.
+
 ## Available Agents
 
 - **`paper-compiler`**: Ingests raw papers into the wiki.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ Rules:
 - CLI is **read-only** from our perspective. All edits still go through `Edit` / `Write` so diffs land in git.
 - Paths are vault-relative (`papers/39506116.md`, not `wiki/papers/39506116.md`).
 - Always pass `format=json` where supported.
+- **Reload after Write.** After any `Write` into `wiki/`, call `obsidian vault=wiki reload` before the next CLI read against that file — the running Obsidian app does not pick up filesystem changes automatically, so stale-index lookups fail silently. See `docs/obsidian-cli.md`.
+- **Narrow Reads for merge-append.** The `Edit` tool requires a prior `Read` on the same file. For large entity pages, use `obsidian vault=wiki outline path=… format=json` to find the section line, then `Read offset=<line> limit=<slice_size>` for just that section — not a full-file Read. See `docs/obsidian-cli.md`.
 
 ## Available Agents
 

--- a/docs/obsidian-cli.md
+++ b/docs/obsidian-cli.md
@@ -1,0 +1,41 @@
+# Obsidian CLI cheat sheet for cbio-kb agents
+
+The Obsidian app ships an official CLI (`obsidian` on PATH). It is a remote-control for a running Obsidian instance, operating on a named vault. For this repo the vault is `wiki` (mapped to `wiki/` on disk).
+
+**Always pass `vault=wiki` as the first argument** so commands don't resolve against whichever vault happens to be active.
+
+Prefer these commands over `Read` / `Grep` / `Glob` when the target lives in `wiki/`. They return structured JSON and cost a fraction of the tokens.
+
+## Quick mapping
+
+| You want to... | Don't | Do |
+| :-- | :-- | :-- |
+| Skim a paper's structure | `Read wiki/papers/{pmid}.md` | `obsidian vault=wiki outline path=papers/{pmid}.md format=json` |
+| Read only frontmatter | `Read` + truncate | `obsidian vault=wiki properties path=papers/{pmid}.md format=json` |
+| Read a single property | `Grep pmid:` | `obsidian vault=wiki property:read name=pmid path=papers/{pmid}.md` |
+| Find entity mentions with context | `Grep -C 3 EGFR wiki/papers` | `obsidian vault=wiki search:context query=EGFR format=json limit=20` |
+| List matching files only | `Grep -l EGFR` | `obsidian vault=wiki search query=EGFR format=json` |
+| Find pages citing an entity | `Grep '\[\[EGFR\]\]' wiki/` | `obsidian vault=wiki backlinks file=EGFR format=json` |
+| List outgoing links of a page | `Grep '\[.*\](.*\.md)'` | `obsidian vault=wiki links path=papers/{pmid}.md` |
+| List files in a wiki folder | `Glob wiki/papers/*.md` | `obsidian vault=wiki files folder=papers` |
+| Lint: unresolved wikilinks | custom walker | `obsidian vault=wiki unresolved format=json` |
+| Lint: orphan / dead-end pages | custom walker | `obsidian vault=wiki orphans` / `deadends` |
+| Pages carrying a tag | grep frontmatter | `obsidian vault=wiki tag name=<tag>` |
+
+## Full-content reads
+
+The CLI can also read the body (`obsidian vault=wiki read path=...`), but for token efficiency prefer `outline` + targeted `search:context` to jump straight to the lines you need. Only fall back to a full read when you actually need surrounding prose.
+
+## Hard rules for agents
+
+- **Only use for `wiki/` content.** `data/raw/`, `schema/`, `.claude/`, code — those still use Read / Grep / Glob.
+- **Never edit via the CLI.** Agents that modify pages (paper-compiler, entity-page-writer, crosslinker) must use `Edit` / `Write` on the underlying file so diffs land in git. The CLI is read-only from our perspective.
+- **Paths are vault-relative**, not filesystem-relative. `path=papers/39506116.md`, not `path=wiki/papers/39506116.md`.
+- **`file=` resolves like a wikilink** (by stem, no extension). `file=EGFR` → `genes/EGFR.md`. Use `path=` when you need to be exact.
+- **JSON please.** Pass `format=json` on every command that supports it — the default TSV is harder to parse and wastes tokens.
+
+## Preconditions
+
+- `obsidian` must be on PATH (`/usr/local/bin/obsidian` on this machine).
+- The Obsidian app must be running; the CLI will auto-launch it otherwise.
+- The `wiki` vault must be registered with Obsidian. Check with `obsidian vaults`.

--- a/docs/obsidian-cli.md
+++ b/docs/obsidian-cli.md
@@ -6,6 +6,11 @@ The Obsidian app ships an official CLI (`obsidian` on PATH). It is a remote-cont
 
 Prefer these commands over `Read` / `Grep` / `Glob` when the target lives in `wiki/`. They return structured JSON and cost a fraction of the tokens.
 
+Two non-obvious rules apply once you start writing files:
+
+- **Call `obsidian vault=wiki reload` after any `Write` into `wiki/`.** Otherwise the CLI will return "File not found" against just-written paths. See "Reload after Write" below.
+- **Use outline-guided narrow Reads for merge-append edits.** The `Edit` tool's "must Read first" precondition would otherwise force full-file Reads that dwarf the CLI savings. See "Narrow reads for merge-append" below.
+
 ## Quick mapping
 
 | You want to... | Don't | Do |
@@ -25,6 +30,48 @@ Prefer these commands over `Read` / `Grep` / `Glob` when the target lives in `wi
 ## Full-content reads
 
 The CLI can also read the body (`obsidian vault=wiki read path=...`), but for token efficiency prefer `outline` + targeted `search:context` to jump straight to the lines you need. Only fall back to a full read when you actually need surrounding prose.
+
+## Reload after Write
+
+The Obsidian CLI is a remote-control for a running Obsidian app. When you create a new file via `Write` (or modify the filesystem outside of Obsidian), the running app does **not** see the change until it re-scans the vault. Subsequent `outline` / `properties` / `search` / `backlinks` calls against the new path will return "File not found" — a silent failure that wastes tool calls.
+
+**Rule: after every `Write` into `wiki/`, call `obsidian vault=wiki reload`.** This is a bare command with no arguments:
+
+```bash
+obsidian vault=wiki reload
+```
+
+One call is enough for any number of file changes; it does not need to be per-file. In practice, run it once at the end of a batch of Writes, or once before the next CLI read against a just-written path.
+
+**Worktree caveat.** Obsidian registers the `wiki` vault at a single absolute path (see `~/Library/Application Support/obsidian/obsidian.json`). Typically that path is the main checkout (`…/cbio-vec/wiki`). When you run an agent from a git worktree (`…/cbio-vec/.worktrees/<branch>/wiki`), the CLI continues to talk to the main-repo vault — so `reload` still exits 0 and prints "Reloading..." but never sees files you wrote inside the worktree. In that case the CLI is effectively unusable for just-written files regardless of reload; you must fall back to `Read` / `Glob` / `ls` for anything touched in the current session. Either (a) run the paper-compilation workflow from the main checkout, (b) temporarily re-register the vault at the worktree's wiki path, or (c) accept the staleness and use Read/Glob for your own Writes. The CLI's non-Write operations (outline, properties, search on pre-existing pages) still work from a worktree as long as those pages exist in main.
+
+## Narrow reads for merge-append
+
+The `Edit` tool requires a prior `Read` on the same file before it will accept an edit. For large entity pages (genes, cancer types) this turns every merge-append into a full-file Read of 5–20k tokens just to find a unique anchor string, which defeats most of the CLI savings.
+
+The win: use `outline` to locate the section you're editing, then `Read` only the line range that section covers. A 10–30 line slice is ~1–2k tokens.
+
+Pattern:
+
+1. Get the heading map:
+   ```bash
+   obsidian vault=wiki outline path=genes/KRAS.md format=json
+   ```
+   Returns `[{level, heading, line}, …]` — the `line` fields are 1-indexed line numbers in the file.
+2. Pick the H2 section you need to edit. For entity-page-writer merges this is usually `## Alterations observed in the corpus`, `## Cancer types (linked)`, or `## Sources`.
+3. Compute the slice: `offset = <section_line>`, `limit = <next_heading_line> - <section_line>` (or a safe upper bound like 30 for the final `## Sources` section, which is always the last H2 before the footer).
+4. Narrow Read:
+   ```
+   Read path=/abs/path/to/wiki/genes/KRAS.md offset=<section_line> limit=<slice_size>
+   ```
+5. `Edit` using an anchor string drawn from the slice.
+
+**Caveat:** `Edit`'s `old_string` must be unique in the *whole* file, not just in the slice. H2 headings and PMID-tagged bullet text are normally unique, but if `Edit` fails with "not unique", fall back to a full-file `Read` and retry with a longer anchor. This should be rare.
+
+For the two most common merge-append operations:
+
+- **Append a PMID to `## Sources`**: `## Sources` is always the last H2. Offset to its line, `limit=30`, and the slice will cover the full list + footer.
+- **Append a bullet to `## Alterations observed in the corpus`**: outline gives both the Alterations line and the next H2 line; Read exactly that range.
 
 ## Hard rules for agents
 

--- a/schema/ontology/_observed.md
+++ b/schema/ontology/_observed.md
@@ -72,3 +72,8 @@
 - method: nlp-prissmm — observed in PMID:39506116 — note: transformer NLP trained on GENIE BPC PRISSMM curation to annotate 705,241 radiology reports for MSK-CHORD
 - method: msk-hemepact — observed in PMID:38995739 — note: MSK-HemePACT ~585-gene heme-focused targeted hybrid-capture panel applied to tumor and CSF ctDNA in r/r CNS lymphoma
 - method: msk-impact-panel — observed in PMID:38995739 — note: MSK-IMPACT referenced alongside MSK-HemePACT in r/r CNS lymphoma ibrutinib trial; used on independent 177-patient PCNSL SOC cohort
+- method: cosmx-smi — observed in PMID:39214094 — note: NanoString CosMx Spatial Molecular Imager high-plex in situ RNA profiling on TMA of 20 PDAC samples (14 tumors, 6 normal)
+- method: msk-impact-panel — observed in PMID:39214094 — note: MSK-IMPACT targeted sequencing on 397/1360 resected PDAC patients for KRAS-allele cohort
+- drug: fluorouracil — observed in PMID:39214094 — note: 5-FU backbone of FOLFIRINOX (neo)adjuvant chemotherapy in resected PDAC
+- drug: irinotecan — observed in PMID:39214094 — note: FOLFIRINOX component in (neo)adjuvant PDAC chemotherapy
+- drug: oxaliplatin — observed in PMID:39214094 — note: FOLFIRINOX component in (neo)adjuvant PDAC chemotherapy

--- a/schema/ontology/_observed.md
+++ b/schema/ontology/_observed.md
@@ -70,3 +70,5 @@
 - method: log-linear-mixed-effects-model — observed in PMID:37910594 — note: longitudinal model for %TVGR per 6 months and doubling time in IDH-mt LGG
 - method: joint-longitudinal-survival-model — observed in PMID:37910594 — note: joint model linking ln(tumor volume) trajectory to NIFS and OS hazard
 - method: nlp-prissmm — observed in PMID:39506116 — note: transformer NLP trained on GENIE BPC PRISSMM curation to annotate 705,241 radiology reports for MSK-CHORD
+- method: msk-hemepact — observed in PMID:38995739 — note: MSK-HemePACT ~585-gene heme-focused targeted hybrid-capture panel applied to tumor and CSF ctDNA in r/r CNS lymphoma
+- method: msk-impact-panel — observed in PMID:38995739 — note: MSK-IMPACT referenced alongside MSK-HemePACT in r/r CNS lymphoma ibrutinib trial; used on independent 177-patient PCNSL SOC cohort

--- a/src/cbio_kb/wiki/lint.py
+++ b/src/cbio_kb/wiki/lint.py
@@ -96,8 +96,20 @@ def run(wiki_dir: Path, allow_orphans: bool = False) -> int:
     index = wiki_dir / "index.md"
     if index.exists():
         index_text = index.read_text()
+        # Sections whose per-section index.qmd uses a Quarto listing with
+        # `contents: "*.md"` auto-include every page in the directory, so any
+        # page under such a section is reachable from the site even if not
+        # named in the top-level index.md.
+        listed_sections: set[str] = set()
+        for qmd in wiki_dir.glob("*/index.qmd"):
+            qtext = qmd.read_text()
+            if re.search(r"contents:\s*\"?\*\.md\"?", qtext):
+                listed_sections.add(qmd.parent.name)
         for rel in all_pages:
             if rel == "index.md":
+                continue
+            section = rel.split("/", 1)[0]
+            if section in listed_sections:
                 continue
             stem = Path(rel).stem
             if stem not in index_text and rel not in index_text:

--- a/wiki/cancer_types/DLBCLNOS.md
+++ b/wiki/cancer_types/DLBCLNOS.md
@@ -1,0 +1,39 @@
+---
+name: Diffuse Large B-Cell Lymphoma NOS
+oncotree_code: DLBCLNOS
+parent: BLL
+tags:
+  - b-cell-lymphoma
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# Diffuse Large B-Cell Lymphoma NOS (DLBCLNOS)
+
+## Overview
+
+Diffuse large B-cell lymphoma, not otherwise specified — the parent OncoTree category encompassing [PCNSL](PCNSL.md) and secondary CNS DLBCL variants.
+
+## Cohorts in the corpus
+
+- [pcnsl_msk_2024](../datasets/pcnsl_msk_2024.md) — 46-patient r/r CNS lymphoma cohort (31 [PCNSL](../cancer_types/PCNSL.md) + 15 SCNSL) treated with [ibrutinib](../drugs/ibrutinib.md) and profiled on [MSK-HemePACT](../methods/msk-hemepact.md) [PMID:38995739](../papers/38995739.md).
+
+## Recurrent alterations
+
+- BCR-pathway drivers dominate the CNS DLBCL subset: [MYD88](../genes/MYD88.md), [CD79B](../genes/CD79B.md), [CARD11](../genes/CARD11.md), and [TBL1XR1](../genes/TBL1XR1.md) [PMID:38995739](../papers/38995739.md).
+
+## Subtypes
+
+- [PCNSL](PCNSL.md) — primary CNS lymphoma, predominantly non-germinal-center [PMID:38995739](../papers/38995739.md).
+- Secondary CNS lymphoma (SCNSL) — systemic DLBCL with CNS involvement; 15 patients in the MSK [ibrutinib](../drugs/ibrutinib.md) cohort with 60% ORR (7 CR) [PMID:38995739](../papers/38995739.md).
+
+## Therapeutic landscape
+
+- [ibrutinib](../drugs/ibrutinib.md) single-agent showed activity in both [PCNSL](../cancer_types/PCNSL.md) (74% ORR) and SCNSL (60% ORR) in r/r disease [PMID:38995739](../papers/38995739.md).
+- [CARD11](../genes/CARD11.md) coiled-coil mutations mark known primary ibrutinib resistance in B-cell malignancies [PMID:38995739](../papers/38995739.md).
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/cancer_types/PAAD.md
+++ b/wiki/cancer_types/PAAD.md
@@ -2,33 +2,43 @@
 name: Pancreatic Adenocarcinoma
 oncotree_code: PAAD
 parent: PANCREAS
-tags: [pancreas]
-processed_by: entity-page-writer
-processed_at: 2026-04-08
+tags: [pancreas, kras-driven]
+processed_by: paper-compiler
+processed_at: 2026-04-09
 ---
 
 # Pancreatic Adenocarcinoma (PAAD)
 
 ## Overview
 
-OncoTree code for pancreatic adenocarcinoma.
+OncoTree code for pancreatic adenocarcinoma. In the corpus, PAAD is characterized by near-universal [KRAS](../genes/KRAS.md) mutation with allele-specific biology, recurrent [TP53](../genes/TP53.md) / [CDKN2A](../genes/CDKN2A.md) / [SMAD4](../genes/SMAD4.md) co-alterations, and clinical behavior strongly shaped by stage at resection.
 
 ## Cohorts in the corpus
 
 - [msk_chord_2024](../datasets/msk_chord_2024.md) — 3,109 pancreatic cancer patients at MSK in the MSK-CHORD clinicogenomic harmonized real-world dataset [PMID:39506116](../papers/39506116.md).
+- [pancreas_msk_2024](../datasets/pancreas_msk_2024.md) — 1,360 consecutive resected PDAC patients at MSK (2004–2019), with [MSK-IMPACT](../methods/msk-impact-panel.md) targeted sequencing on 397, bulk RNA-seq on 100, and [CosMx SMI](../methods/cosmx-smi.md) spatial profiling on 20 [PMID:39214094](../papers/39214094.md).
 
 ## Recurrent alterations
 
 - Included in pan-cancer MSK-IMPACT pathway and metastasis analyses [PMID:39506116](../papers/39506116.md).
+- Canonical driver frequencies in the resected MSK cohort (n=397 sequenced): [KRAS](../genes/KRAS.md) 90%, [TP53](../genes/TP53.md) 71%, [CDKN2A](../genes/CDKN2A.md) 24%, [SMAD4](../genes/SMAD4.md) 17%; no significant difference in these frequencies between early- and late-stage disease after multiple-testing correction [PMID:39214094](../papers/39214094.md).
+- KRAS allele distribution: G12D 36.5%, G12V 32.5%, G12R 13.9%, other KRAS 8.1%, KRAS wildtype 9.1% [PMID:39214094](../papers/39214094.md).
+- KRAS^G12R^ tumors carry a higher proportion of CDKN2A mutations than KRAS^G12D^ (40% vs 22.1%, p=0.046) [PMID:39214094](../papers/39214094.md).
 
 ## Subtypes
+
+- KRAS^G12R^-mutant PDAC is a distinct clinical subset: enriched in stage I disease (23% vs 11% in stage II–III, p=0.022), more often node-negative (47% vs 26% for KRAS^G12D^, p=0.019), with improved OS and decreased distant recurrence compared to KRAS^G12D^; also associated with family history of pancreatic cancer (16.4% vs 4.2%, p=0.003) [PMID:39214094](../papers/39214094.md).
+- Transcriptional programs diverge by KRAS allele: KRAS^G12D^ tumors show enhanced KRAS signaling and EMT; KRAS^G12R^ tumors show increased TNF/NF-κB signaling by both bulk RNA-seq and [CosMx SMI](../methods/cosmx-smi.md) spatial profiling [PMID:39214094](../papers/39214094.md).
 
 ## Therapeutic landscape
 
 - NLP-augmented integrated survival-prediction models outperformed stage- or genomics-only models [PMID:39506116](../papers/39506116.md).
+- KRAS^G12R^ resected PDAC was enriched among patients who received neoadjuvant [fluorouracil](../drugs/fluorouracil.md)-based chemotherapy (most frequently FOLFIRINOX with [irinotecan](../drugs/irinotecan.md) and [oxaliplatin](../drugs/oxaliplatin.md)), consistent with higher response likelihood rather than borderline-resectable selection [PMID:39214094](../papers/39214094.md).
+- Allele-specific transcriptional divergence (NF-κB vs KRAS/EMT) suggests divergent actionable dependencies across KRAS-mutant PDAC rather than a single pan-KRAS strategy [PMID:39214094](../papers/39214094.md).
 
 ## Sources
 
 - [PMID:39506116](../papers/39506116.md)
+- [PMID:39214094](../papers/39214094.md)
 
-*This page was processed by **entity-page-writer** on **2026-04-08**.*
+*This page was processed by **paper-compiler** on **2026-04-09**.*

--- a/wiki/cancer_types/PCNSL.md
+++ b/wiki/cancer_types/PCNSL.md
@@ -1,0 +1,43 @@
+---
+name: Primary CNS Lymphoma
+oncotree_code: PCNSL
+parent: DLBCLNOS
+tags:
+  - cns-lymphoma
+  - b-cell-lymphoma
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# Primary CNS Lymphoma (PCNSL)
+
+## Overview
+
+Primary central nervous system lymphoma, an aggressive extranodal non-Hodgkin lymphoma confined to the brain, spinal cord, leptomeninges, or eye; classified under DLBCL NOS in OncoTree.
+
+## Cohorts in the corpus
+
+- [pcnsl_msk_2024](../datasets/pcnsl_msk_2024.md) — 31 r/r PCNSL patients sequenced on [MSK-HemePACT](../methods/msk-hemepact.md) as part of a phase I/II [ibrutinib](../drugs/ibrutinib.md) trial at MSK [PMID:38995739](../papers/38995739.md).
+
+## Recurrent alterations
+
+- [MYD88](../genes/MYD88.md) — mutated in 72% of the PCNSL cohort [PMID:38995739](../papers/38995739.md).
+- [CD79B](../genes/CD79B.md) — mutated in 48% of the PCNSL cohort [PMID:38995739](../papers/38995739.md).
+- [TBL1XR1](../genes/TBL1XR1.md) — WD40-domain (likely LoF) mutations in 36% of PCNSL cases [PMID:38995739](../papers/38995739.md).
+- [CARD11](../genes/CARD11.md) — mutated in 24% of PCNSL cases [PMID:38995739](../papers/38995739.md).
+
+## Subtypes
+
+- 21/25 (84%) of profiled PCNSLs in the MSK cohort were non-germinal-center (Hans classifier) [PMID:38995739](../papers/38995739.md).
+
+## Therapeutic landscape
+
+- [ibrutinib](../drugs/ibrutinib.md) single-agent 840 mg/day produced 74% ORR (12 CR) in r/r PCNSL; ~10% of patients achieved >3-year durable responses. [TBL1XR1](../genes/TBL1XR1.md) mutation predicted longer PFS (16.5 vs 3.1 months, p=0.0075); [MYD88](../genes/MYD88.md) mutation also associated with longer PFS (9.2 vs 2.9 months); [CARD11](../genes/CARD11.md) coiled-coil mutations marked shorter PFS (2.2 vs 5.5 months) [PMID:38995739](../papers/38995739.md).
+- CSF ctDNA clearance within 4 weeks on ibrutinib correlated with complete and durable response [PMID:38995739](../papers/38995739.md).
+- Prior lines in the cohort included [methotrexate](../drugs/methotrexate.md) (universal), [temozolomide](../drugs/temozolomide.md), [temsirolimus](../drugs/temsirolimus.md), [lenalidomide](../drugs/lenalidomide.md), and [pembrolizumab](../drugs/pembrolizumab.md) [PMID:38995739](../papers/38995739.md).
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/datasets/pancreas_msk_2024.md
+++ b/wiki/datasets/pancreas_msk_2024.md
@@ -1,0 +1,50 @@
+---
+name: MSK Resected PDAC KRAS-Allele Cohort (2024)
+slug: pancreas_msk_2024
+institution: Memorial Sloan Kettering Cancer Center
+size: 1360
+assays:
+  - msk-impact-panel
+  - cosmx-smi
+tags:
+  - pdac
+  - kras-alleles
+  - surgical-resection
+  - spatial-transcriptomics
+processed_by: paper-compiler
+processed_at: 2026-04-09
+---
+
+# MSK Resected PDAC KRAS-Allele Cohort (2024)
+
+## Overview
+
+Single-institution retrospective cohort of 1,360 consecutive patients with pancreatic ductal adenocarcinoma who underwent surgical resection at Memorial Sloan Kettering between April 2004 and April 2019, assembled to interrogate KRAS allele–specific clinical outcomes and biology in [PAAD](../cancer_types/PAAD.md) [PMID:39214094](../papers/39214094.md).
+
+## Composition
+
+- 1,360 resected PDAC patients; 397 (29%) stage I, 963 (71%) stage II–III; OS of the full cohort 30.7 months (95% CI 28.0–32.8) [PMID:39214094](../papers/39214094.md).
+- Tumor targeted sequencing on [MSK-IMPACT](../methods/msk-impact-panel.md) in 397 patients (103 stage I, 294 stage II–III) with no sequencing selection criteria [PMID:39214094](../papers/39214094.md).
+- Bulk RNA-seq on 100 resected tumors and high-plex spatial profiling on 20 patients (14 tumors, 6 normal) using NanoString [CosMx SMI](../methods/cosmx-smi.md) tissue microarrays [PMID:39214094](../papers/39214094.md).
+- 22% of the sequenced subset received neoadjuvant therapy (most commonly 5-FU–based regimens, frequently FOLFIRINOX); 82% received adjuvant therapy [PMID:39214094](../papers/39214094.md).
+
+## Assays / panels (linked)
+
+- [MSK-IMPACT](../methods/msk-impact-panel.md) — targeted tumor sequencing, used for driver-gene and KRAS-allele calls across the 397-patient sequenced subset [PMID:39214094](../papers/39214094.md).
+- [CosMx SMI](../methods/cosmx-smi.md) — NanoString high-plex spatial molecular imaging on TMAs for the 20-patient spatial subcohort [PMID:39214094](../papers/39214094.md).
+
+## Papers using this cohort
+
+- [PMID:39214094](../papers/39214094.md) — McIntyre et al., Cancer Cell 2024. KRAS^G12R^ enrichment in early-stage PDAC with distinct clinical outcomes and NF-κB-biased transcriptional program.
+
+## Notable findings derived from this cohort
+
+- [KRAS](../genes/KRAS.md) altered in 90%, [TP53](../genes/TP53.md) 71%, [CDKN2A](../genes/CDKN2A.md) 24%, [SMAD4](../genes/SMAD4.md) 17%; KRAS allele distribution G12D 36.5% / G12V 32.5% / G12R 13.9% / other 8.1% / WT 9.1% [PMID:39214094](../papers/39214094.md).
+- KRAS^G12R^ enriched in stage I disease (23% vs 11%), more often node-negative (47% vs 26% for G12D), and associated with improved OS and reduced distant recurrence [PMID:39214094](../papers/39214094.md).
+- KRAS^G12R^ tumors carry a higher frequency of [CDKN2A](../genes/CDKN2A.md) mutations than KRAS^G12D^ (40% vs 22.1%) [PMID:39214094](../papers/39214094.md).
+
+## Sources
+
+- cBioPortal study: https://www.cbioportal.org/study/summary?id=pancreas_msk_2024
+
+*This page was processed by **paper-compiler** on **2026-04-09**.*

--- a/wiki/datasets/pcnsl_msk_2024.md
+++ b/wiki/datasets/pcnsl_msk_2024.md
@@ -1,0 +1,49 @@
+---
+name: PCNSL MSK Ibrutinib Phase I/II Cohort (2024)
+slug: pcnsl_msk_2024
+institution: Memorial Sloan Kettering Cancer Center
+size: 46
+assays:
+  - msk-hemepact
+  - msk-impact-panel
+tags:
+  - cns-lymphoma
+  - phase-ii-trial
+  - btk-inhibitor
+  - csf-ctdna
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# PCNSL MSK Ibrutinib Phase I/II Cohort (2024)
+
+## Overview
+
+Single-center phase I/II trial cohort (NCT02315326) at Memorial Sloan Kettering of 46 patients with relapsed/refractory CNS lymphoma treated with single-agent ibrutinib, with paired tumor and CSF genomic profiling [PMID:38995739](../papers/38995739.md).
+
+## Composition
+
+- 46 patients with r/r CNS lymphoma: 31 [PCNSL](../cancer_types/PCNSL.md) + 15 SCNSL (secondary CNS [DLBCLNOS](../cancer_types/DLBCLNOS.md)); median age 68 (range 21–90); median 2 prior therapies; all previously received [methotrexate](../drugs/methotrexate.md) [PMID:38995739](../papers/38995739.md).
+- Archival tumor biopsies sequenced in 25/31 PCNSL cases; paired pre-/on-treatment CSF (CSF1/CSF2) available for 14 patients [PMID:38995739](../papers/38995739.md).
+
+## Assays / panels (linked)
+
+- [MSK-HemePACT](../methods/msk-hemepact.md) — 585-gene hematologic-focused targeted panel on tumor and CSF ctDNA with matched germline [PMID:38995739](../papers/38995739.md).
+- [MSK-IMPACT](../methods/msk-impact-panel.md) — used in independent MSK PCNSL SOC cohort for comparison [PMID:38995739](../papers/38995739.md).
+
+## Papers using this cohort
+
+- [PMID:38995739](../papers/38995739.md) — Grommes et al., Clin Cancer Res 2024. Phase II long-term [ibrutinib](../drugs/ibrutinib.md) in r/r CNS lymphoma.
+
+## Notable findings derived from this cohort
+
+- BCR-pathway alteration landscape: [MYD88](../genes/MYD88.md) 72%, [CD79B](../genes/CD79B.md) 48%, [CARD11](../genes/CARD11.md) 24%, [TBL1XR1](../genes/TBL1XR1.md) 36%; 84% non-germinal center by Hans classifier [PMID:38995739](../papers/38995739.md).
+- [TBL1XR1](../genes/TBL1XR1.md) WD40-domain mutations predicted prolonged [ibrutinib](../drugs/ibrutinib.md) PFS (16.5 vs 3.1 months, p=0.0075) [PMID:38995739](../papers/38995739.md).
+- [MYD88](../genes/MYD88.md) mutation associated with longer PFS on ibrutinib (9.2 vs 2.9 months, p=0.027); [CARD11](../genes/CARD11.md) mutation with shorter PFS (2.2 vs 5.5 months) [PMID:38995739](../papers/38995739.md).
+- CSF ctDNA clearance within 4 weeks correlated with complete and long-term ibrutinib response [PMID:38995739](../papers/38995739.md).
+
+## Sources
+
+- cBioPortal study: https://www.cbioportal.org/study/summary?id=pcnsl_msk_2024
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/drugs/ibrutinib.md
+++ b/wiki/drugs/ibrutinib.md
@@ -5,7 +5,7 @@ drug_class: BTK inhibitor
 unverified: true
 tags: [targeted-therapy, cll]
 processed_by: crosslinker
-processed_at: 2026-04-08
+processed_at: 2026-04-09
 ---
 
 # ibrutinib
@@ -30,4 +30,4 @@ Covalent BTK inhibitor; standard-of-care in CLL and other B-cell malignancies.
 
 - [PMID:35927489](../papers/35927489.md)
 
-*This page was processed by **crosslinker** on **2026-04-08**.*
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/drugs/lenalidomide.md
+++ b/wiki/drugs/lenalidomide.md
@@ -1,0 +1,33 @@
+---
+name: lenalidomide
+targets: [CRBN]
+drug_class: immunomodulatory agent (IMiD, cereblon E3 ligase modulator)
+tags: [imid, cns-lymphoma]
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# lenalidomide
+
+## Overview
+
+Cereblon-binding immunomodulatory agent with activity in B-cell lymphomas, including CNS lymphoma salvage regimens.
+
+## Evidence in the corpus
+
+- Listed among prior salvage therapies received by r/r CNS lymphoma patients in the MSK [ibrutinib](../drugs/ibrutinib.md) phase I/II trial [PMID:38995739](../papers/38995739.md).
+
+## Resistance mechanisms
+
+- Not directly characterized in the corpus.
+
+## Cancer types (linked)
+
+- [PCNSL](../cancer_types/PCNSL.md)
+- [DLBCLNOS](../cancer_types/DLBCLNOS.md)
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/drugs/methotrexate.md
+++ b/wiki/drugs/methotrexate.md
@@ -1,0 +1,33 @@
+---
+name: methotrexate
+targets: [DHFR]
+drug_class: antifolate chemotherapy
+tags: [chemotherapy, cns-lymphoma, standard-of-care]
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# methotrexate
+
+## Overview
+
+Antifolate chemotherapy; high-dose methotrexate is the backbone of first-line therapy for primary CNS lymphoma.
+
+## Evidence in the corpus
+
+- All 46 r/r CNS lymphoma patients enrolled in the MSK [ibrutinib](../drugs/ibrutinib.md) phase I/II trial had previously received methotrexate, establishing it as the standard frontline therapy prior to BTK inhibition [PMID:38995739](../papers/38995739.md).
+
+## Resistance mechanisms
+
+- Not directly characterized in the corpus.
+
+## Cancer types (linked)
+
+- [PCNSL](../cancer_types/PCNSL.md)
+- [DLBCLNOS](../cancer_types/DLBCLNOS.md)
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/drugs/pembrolizumab.md
+++ b/wiki/drugs/pembrolizumab.md
@@ -5,7 +5,7 @@ drug_class: anti-PD-1 monoclonal antibody
 unverified: true
 tags: [immunotherapy, checkpoint-inhibitor]
 processed_by: crosslinker
-processed_at: 2026-04-08
+processed_at: 2026-04-09
 ---
 
 # pembrolizumab
@@ -31,4 +31,4 @@ Humanized anti-PD-1 immune checkpoint inhibitor with tumor-agnostic TMB-H approv
 
 - [PMID:36862133](../papers/36862133.md)
 
-*This page was processed by **crosslinker** on **2026-04-08**.*
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/drugs/temozolomide.md
+++ b/wiki/drugs/temozolomide.md
@@ -1,0 +1,32 @@
+---
+name: temozolomide
+targets: []
+drug_class: alkylating chemotherapy
+tags: [chemotherapy, cns-lymphoma]
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# temozolomide
+
+## Overview
+
+Oral alkylating agent used in CNS malignancies, including as a component of salvage regimens in relapsed/refractory CNS lymphoma.
+
+## Evidence in the corpus
+
+- Listed among prior therapies received by patients in the MSK r/r CNS lymphoma [ibrutinib](../drugs/ibrutinib.md) cohort [PMID:38995739](../papers/38995739.md).
+
+## Resistance mechanisms
+
+- Not directly characterized in the corpus.
+
+## Cancer types (linked)
+
+- [PCNSL](../cancer_types/PCNSL.md)
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/drugs/temsirolimus.md
+++ b/wiki/drugs/temsirolimus.md
@@ -5,7 +5,7 @@ drug_class: mTOR inhibitor
 unverified: true
 tags: [targeted-therapy]
 processed_by: crosslinker
-processed_at: 2026-04-08
+processed_at: 2026-04-09
 ---
 
 # temsirolimus
@@ -30,4 +30,4 @@ Rapamycin-ester mTOR inhibitor; used in pediatric sarcoma trial regimens (e.g., 
 
 - [PMID:37315267](../papers/37315267.md)
 
-*This page was processed by **crosslinker** on **2026-04-08**.*
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/drugs/tirabrutinib.md
+++ b/wiki/drugs/tirabrutinib.md
@@ -1,0 +1,32 @@
+---
+name: tirabrutinib
+targets: [BTK]
+drug_class: BTK inhibitor (second-generation, covalent)
+tags: [btk-inhibitor, cns-lymphoma]
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# tirabrutinib
+
+## Overview
+
+Second-generation covalent BTK inhibitor. Under evaluation in CNS lymphoma as a more selective alternative to [ibrutinib](../drugs/ibrutinib.md).
+
+## Evidence in the corpus
+
+- Flagged as an ongoing second-generation BTK inhibitor trial context for testing whether [TBL1XR1](../genes/TBL1XR1.md)-driven benefit from BTK inhibition in [PCNSL](../cancer_types/PCNSL.md) generalizes beyond [ibrutinib](../drugs/ibrutinib.md) [PMID:38995739](../papers/38995739.md).
+
+## Resistance mechanisms
+
+- Not directly reported in the corpus.
+
+## Cancer types (linked)
+
+- [PCNSL](../cancer_types/PCNSL.md)
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/genes/CARD11.md
+++ b/wiki/genes/CARD11.md
@@ -1,0 +1,45 @@
+---
+symbol: CARD11
+aliases: []
+cancer_types:
+  - PCNSL
+  - DLBCLNOS
+tags:
+  - bcr-pathway
+  - ibrutinib-resistance
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# CARD11
+
+## Overview
+
+CARD11 is a scaffold protein in the CBM complex that couples BCR signaling to NF-kB activation. Coiled-coil domain mutations produce BTK-independent NF-kB activation and are a recognized mechanism of primary [ibrutinib](../drugs/ibrutinib.md) resistance in B-cell lymphomas.
+
+## Alterations observed in the corpus
+
+- Mutated in 6 patients (24%) of the sequenced [PCNSL](../cancer_types/PCNSL.md) subset in the MSK [ibrutinib](../drugs/ibrutinib.md) phase II trial; mutations mapped to the coiled-coil domain [PMID:38995739](../papers/38995739.md).
+
+## Cancer types (linked)
+
+- [PCNSL](../cancer_types/PCNSL.md) — CARD11-mutant PCNSLs had shorter PFS on [ibrutinib](../drugs/ibrutinib.md) (median 2.2 vs 5.5 months), consistent with prior reports of CARD11-mediated ibrutinib resistance in B-cell malignancies [PMID:38995739](../papers/38995739.md).
+- [DLBCLNOS](../cancer_types/DLBCLNOS.md) — established site of CARD11-mediated BTK-independent NF-kB activation [PMID:38995739](../papers/38995739.md).
+
+## Co-occurrence and mutual exclusivity
+
+- Co-occurs with [MYD88](MYD88.md), [CD79B](CD79B.md), and [TBL1XR1](TBL1XR1.md) in non-GCB [PCNSL](../cancer_types/PCNSL.md) [PMID:38995739](../papers/38995739.md).
+
+## Therapeutic relevance
+
+- Coiled-coil-domain CARD11 mutations mark likely primary resistance to [ibrutinib](../drugs/ibrutinib.md) and other BTK inhibitors; patients may require combination strategies bypassing BTK [PMID:38995739](../papers/38995739.md).
+
+## Open questions
+
+- Whether downstream NF-kB or MALT1 inhibition can rescue response in CARD11-mutant [PCNSL](../cancer_types/PCNSL.md) [PMID:38995739](../papers/38995739.md).
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/genes/CD79B.md
+++ b/wiki/genes/CD79B.md
@@ -1,0 +1,44 @@
+---
+symbol: CD79B
+aliases: []
+cancer_types:
+  - PCNSL
+  - DLBCLNOS
+tags:
+  - bcr-pathway
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# CD79B
+
+## Overview
+
+CD79B encodes the Ig-beta component of the B-cell receptor. ITAM-domain mutations (notably Y196) drive chronic active BCR signaling and are recurrent in activated B-cell DLBCL and primary CNS lymphoma.
+
+## Alterations observed in the corpus
+
+- Mutated in 48% of PCNSLs profiled with [MSK-HemePACT](../methods/msk-hemepact.md) in the MSK [ibrutinib](../drugs/ibrutinib.md) phase II trial [PMID:38995739](../papers/38995739.md).
+
+## Cancer types (linked)
+
+- [PCNSL](../cancer_types/PCNSL.md) — canonical BCR-pathway driver; part of the non-germinal-center (Hans classifier) profile that dominated the MSK [ibrutinib](../drugs/ibrutinib.md) cohort (21/25, 84%) [PMID:38995739](../papers/38995739.md).
+- [DLBCLNOS](../cancer_types/DLBCLNOS.md) — established ABC-subtype driver [PMID:38995739](../papers/38995739.md).
+
+## Co-occurrence and mutual exclusivity
+
+- Co-occurs with [MYD88](MYD88.md), [CARD11](CARD11.md), and [TBL1XR1](TBL1XR1.md) in non-GCB [PCNSL](../cancer_types/PCNSL.md) [PMID:38995739](../papers/38995739.md).
+
+## Therapeutic relevance
+
+- CD79B mutations drive BCR-pathway dependence, the rationale for [ibrutinib](../drugs/ibrutinib.md) treatment in [PCNSL](../cancer_types/PCNSL.md); the MSK phase II trial did not report an independent PFS association for CD79B status [PMID:38995739](../papers/38995739.md).
+
+## Open questions
+
+- Whether CD79B status refines the [TBL1XR1](TBL1XR1.md)/[MYD88](MYD88.md) predictive signal for BTK inhibitor benefit in [PCNSL](../cancer_types/PCNSL.md) [PMID:38995739](../papers/38995739.md).
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/genes/CDKN2A.md
+++ b/wiki/genes/CDKN2A.md
@@ -1,10 +1,10 @@
 ---
 symbol: CDKN2A
 aliases: []
-cancer_types: [PTCL, MEITL, LUAD, NSCLC, RMS, ARMS, BLCA, UTUC]
-tags: [cell-cycle, tumor-suppressor, deletion, prognostic]
-processed_by: entity-page-writer
-processed_at: 2026-04-08
+cancer_types: [PTCL, MEITL, LUAD, NSCLC, RMS, ARMS, BLCA, UTUC, PAAD]
+tags: [cell-cycle, tumor-suppressor, deletion, prognostic, kras-allele-specific]
+processed_by: paper-compiler
+processed_at: 2026-04-09
 ---
 
 # CDKN2A
@@ -23,6 +23,7 @@ CDKN2A encodes the p16^INK4a and p14^ARF tumor suppressors that restrain CDK4/6-
 - Homozygous CDKN2A/B deletion ("molecular grade-high") drove ~2x faster tumor-volume growth (19.17% per 6 months vs 9.54%) in IDH-mutant WHO Grade 2 low-grade glioma on active surveillance, supporting WHO 2021 Grade 4 upgrade [PMID:37910594](../papers/37910594.md).
 - High small bowel [GIST](../cancer_types/GIST.md) risk class in an elastic-net Cox genomic risk model was defined in part by CDKN2A alterations (along with [RB1](../genes/RB1.md) and MAX/MGA/MYC) [PMID:37477937](../papers/37477937.md).
 - CDKN2A loss characterized "biliary-class" intrahepatic cholangiocarcinoma (along with [KRAS](../genes/KRAS.md) and [SMAD4](../genes/SMAD4.md)) in the MSK hidden-genome classifier cohort, associated with markedly worse OS [PMID:38864854](../papers/38864854.md).
+- In 397 sequenced resected [PAAD](../cancer_types/PAAD.md) patients (MSK `pancreas_msk_2024`), CDKN2A mutations were enriched in [KRAS](../genes/KRAS.md)^G12R^ tumors (40%) versus KRAS^G12D^ (22.1%, p=0.046); overall CDKN2A mutation rate 24% (95/397); CDKN2A/B deep deletions were notably under-detected on MSK-IMPACT in this PDAC cohort [PMID:39214094](../papers/39214094.md).
 
 ## Cancer types (linked)
 
@@ -30,6 +31,7 @@ CDKN2A encodes the p16^INK4a and p14^ARF tumor suppressors that restrain CDK4/6-
 - [LUAD](../cancer_types/LUAD.md) — CDKN2A loss shortens time to metastasis and is enriched in CNS/liver mets [PMID:37084736](../papers/37084736.md).
 - [NSCLC](../cancer_types/NSCLC.md) brain metastasis — CDKN2A/B deletions are enriched vs primaries, marking cell-cycle dysregulation as near-obligate for BM development [PMID:37591896](../papers/37591896.md).
 - Extremity alveolar [RMS](../cancer_types/RMS.md) — CDKN2A deletion is recurrent and adverse [PMID:37315267](../papers/37315267.md).
+- [PAAD](../cancer_types/PAAD.md) — CDKN2A mutation rate is KRAS-allele-dependent, enriched in KRAS^G12R^ relative to KRAS^G12D^ tumors [PMID:39214094](../papers/39214094.md).
 
 ## Co-occurrence and mutual exclusivity
 
@@ -55,5 +57,6 @@ CDKN2A encodes the p16^INK4a and p14^ARF tumor suppressors that restrain CDK4/6-
 - [PMID:37910594](../papers/37910594.md)
 - [PMID:37477937](../papers/37477937.md)
 - [PMID:38864854](../papers/38864854.md)
+- [PMID:39214094](../papers/39214094.md)
 
-*This page was processed by **entity-page-writer** on **2026-04-08**.*
+*This page was processed by **paper-compiler** on **2026-04-09**.*

--- a/wiki/genes/KRAS.md
+++ b/wiki/genes/KRAS.md
@@ -1,10 +1,10 @@
 ---
 symbol: KRAS
 aliases: []
-cancer_types: [LUAD, LUSC, APAD, LCH, ECD, NSCLC]
-tags: [oncogene, mapk, driver]
-processed_by: entity-page-writer
-processed_at: 2026-04-08
+cancer_types: [LUAD, LUSC, APAD, LCH, ECD, NSCLC, PAAD]
+tags: [oncogene, mapk, driver, allele-specific]
+processed_by: paper-compiler
+processed_at: 2026-04-09
 ---
 
 # KRAS
@@ -23,6 +23,7 @@ KRAS is a canonical RAS-family oncogene and one of the most frequently mutated d
 - [NSCLC](../cancer_types/NSCLC.md) brain metastases: KRAS commonly shared (truncal) between BM and matched primary or extracranial metastasis [PMID:37591896](../papers/37591896.md).
 - KRAS was included in [LUAD](../cancer_types/LUAD.md) pathway/metastasis analyses in MSK-CHORD (n=24,950) [PMID:39506116](../papers/39506116.md).
 - KRAS alterations characterized "biliary-class" intrahepatic cholangiocarcinoma (along with [SMAD4](../genes/SMAD4.md) and [CDKN2A](../genes/CDKN2A.md) loss), associated with markedly worse OS [PMID:38864854](../papers/38864854.md).
+- In 1,360 resected [PAAD](../cancer_types/PAAD.md) patients at MSK (`pancreas_msk_2024`, 397 sequenced on [MSK-IMPACT](../methods/msk-impact-panel.md)), KRAS was altered in 90%; allele distribution G12D 36.5% / G12V 32.5% / G12R 13.9% / other 8.1% / WT 9.1%. KRAS^G12R^ was enriched in stage I (23% vs 11% in stage II–III, p=0.022), more often node-negative (47% vs 26% for G12D, p=0.019), and associated with improved OS and decreased distant recurrence; bulk RNA-seq (n=100) and [CosMx SMI](../methods/cosmx-smi.md) spatial profiling (n=20) identified enhanced KRAS signaling / EMT in KRAS^G12D^ tumors and increased TNF/NF-κB signaling in KRAS^G12R^; isogenic Kras^G12R/+^;Trp53^KO^ mouse PDAC organoids recapitulated reduced migration and improved orthotopic survival [PMID:39214094](../papers/39214094.md).
 
 ## Cancer types (linked)
 
@@ -30,6 +31,7 @@ KRAS is a canonical RAS-family oncogene and one of the most frequently mutated d
 - [APAD](../cancer_types/APAD.md) — RAS-mut predominant MAAP subtype has best prognosis and 50% first-line chemotherapy response [PMID:36493333](../papers/36493333.md).
 - [LCH](../cancer_types/LCH.md) / [ECD](../cancer_types/ECD.md) — KRAS mutated in 7% of histiocytosis [PMID:36862133](../papers/36862133.md).
 - Advanced [NSCLC](../cancer_types/NSCLC.md) — ctDNA-detected KRAS associated with worse prognosis [PMID:36357680](../papers/36357680.md).
+- [PAAD](../cancer_types/PAAD.md) — KRAS altered in 90% of resected PDAC; G12R is prognostically favorable (early-stage, node-negative, longer OS) while G12D drives canonical KRAS/EMT programs [PMID:39214094](../papers/39214094.md).
 
 ## Co-occurrence and mutual exclusivity
 
@@ -44,6 +46,7 @@ KRAS is a canonical RAS-family oncogene and one of the most frequently mutated d
 ## Open questions
 
 - Mechanistic basis for apparent loss of KRAS G12C clones in matched liver metastases of [LUAD](../cancer_types/LUAD.md) is unresolved [PMID:37084736](../papers/37084736.md).
+- Mechanistic basis for reduced metastatic propensity of KRAS^G12R^ [PAAD](../cancer_types/PAAD.md) beyond the NF-κB / EMT axis identified by spatial profiling and organoids remains to be resolved [PMID:39214094](../papers/39214094.md).
 
 ## Sources
 
@@ -54,5 +57,6 @@ KRAS is a canonical RAS-family oncogene and one of the most frequently mutated d
 - [PMID:37591896](../papers/37591896.md)
 - [PMID:39506116](../papers/39506116.md)
 - [PMID:38864854](../papers/38864854.md)
+- [PMID:39214094](../papers/39214094.md)
 
-*This page was processed by **entity-page-writer** on **2026-04-08**.*
+*This page was processed by **paper-compiler** on **2026-04-09**.*

--- a/wiki/genes/MYD88.md
+++ b/wiki/genes/MYD88.md
@@ -1,10 +1,10 @@
 ---
 symbol: MYD88
 aliases: []
-cancer_types: [CLLSLL]
-tags: [nfkb, m-cll, temporal-ordering]
+cancer_types: [CLLSLL, PCNSL, DLBCLNOS]
+tags: [nfkb, m-cll, temporal-ordering, bcr-pathway]
 processed_by: crosslinker
-processed_at: 2026-04-08
+processed_at: 2026-04-09
 ---
 
 # MYD88
@@ -16,25 +16,29 @@ MYD88 is a TLR/IL-1R adaptor and a recurrent driver in lymphoid malignancies inc
 ## Alterations observed in the corpus
 
 - Temporal ordering via [PhylogicNDT](../methods/phylogicndt.md) placed MYD88 mutation as an early event in M-CLL [PMID:35927489](../papers/35927489.md).
+- Mutated in 72% of PCNSLs profiled with [MSK-HemePACT](../methods/msk-hemepact.md) in the MSK [ibrutinib](../drugs/ibrutinib.md) phase II trial [PMID:38995739](../papers/38995739.md).
 
 ## Cancer types (linked)
 
 - [CLLSLL](../cancer_types/CLLSLL.md) — early M-CLL driver in the integrated CLL map (n=1,148) [PMID:35927489](../papers/35927489.md).
+- [PCNSL](../cancer_types/PCNSL.md) — dominant BCR-pathway driver; MYD88-mutant PCNSLs had median PFS of 9.2 vs 2.9 months on [ibrutinib](../drugs/ibrutinib.md) (p=0.027, HR 0.39) [PMID:38995739](../papers/38995739.md).
+- [DLBCLNOS](../cancer_types/DLBCLNOS.md) — canonical ABC-subtype driver; context for secondary CNS lymphoma in the MSK ibrutinib cohort [PMID:38995739](../papers/38995739.md).
 
 ## Co-occurrence and mutual exclusivity
 
-- None reported.
+- Frequently co-occurs with [CD79B](CD79B.md), [CARD11](CARD11.md), and [TBL1XR1](TBL1XR1.md) mutations in non-germinal-center [PCNSL](../cancer_types/PCNSL.md) [PMID:38995739](../papers/38995739.md).
 
 ## Therapeutic relevance
 
-- None reported.
+- MYD88 mutation is associated with longer PFS on [ibrutinib](../drugs/ibrutinib.md) monotherapy in r/r [PCNSL](../cancer_types/PCNSL.md) [PMID:38995739](../papers/38995739.md).
 
 ## Open questions
 
-- None noted.
+- Exploratory, underpowered biomarker association (n=46 trial) that needs prospective validation [PMID:38995739](../papers/38995739.md).
 
 ## Sources
 
 - [PMID:35927489](../papers/35927489.md)
+- [PMID:38995739](../papers/38995739.md)
 
-*This page was processed by **crosslinker** on **2026-04-08**.*
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/genes/SMAD4.md
+++ b/wiki/genes/SMAD4.md
@@ -1,10 +1,10 @@
 ---
 symbol: SMAD4
 aliases: []
-cancer_types: [IHCH]
+cancer_types: [IHCH, PAAD]
 tags: [tumor-suppressor, tgf-beta]
-processed_by: entity-page-writer
-processed_at: 2026-04-08
+processed_by: paper-compiler
+processed_at: 2026-04-09
 ---
 
 # SMAD4
@@ -16,10 +16,12 @@ SMAD4 is a tumor suppressor central to TGF-beta signaling; loss-of-function muta
 ## Alterations observed in the corpus
 
 - SMAD4 alterations characterized "biliary-class" intrahepatic cholangiocarcinoma (along with [KRAS](../genes/KRAS.md) and [CDKN2A](../genes/CDKN2A.md) loss) in the MSK hidden-genome classifier (n=527 IHC), associated with markedly worse OS than HCC-class IHC [PMID:38864854](../papers/38864854.md).
+- In 397 sequenced resected [PAAD](../cancer_types/PAAD.md) patients (MSK `pancreas_msk_2024`), SMAD4 was mutated in 17% (68/397); no difference by [KRAS](../genes/KRAS.md) allele or by early- vs late-stage disease [PMID:39214094](../papers/39214094.md).
 
 ## Cancer types (linked)
 
 - [IHCH](../cancer_types/IHCH.md) — SMAD4 is enriched in biliary-class IHC and discriminative of EHC/GBC-like genetics [PMID:38864854](../papers/38864854.md).
+- [PAAD](../cancer_types/PAAD.md) — mutated in 17% of MSK resected PDAC; a canonical PDAC driver gene [PMID:39214094](../papers/39214094.md).
 
 ## Co-occurrence and mutual exclusivity
 
@@ -36,5 +38,6 @@ SMAD4 is a tumor suppressor central to TGF-beta signaling; loss-of-function muta
 ## Sources
 
 - [PMID:38864854](../papers/38864854.md)
+- [PMID:39214094](../papers/39214094.md)
 
-*This page was processed by **entity-page-writer** on **2026-04-08**.*
+*This page was processed by **paper-compiler** on **2026-04-09**.*

--- a/wiki/genes/TBL1XR1.md
+++ b/wiki/genes/TBL1XR1.md
@@ -1,0 +1,44 @@
+---
+symbol: TBL1XR1
+aliases: []
+cancer_types:
+  - PCNSL
+tags:
+  - wd40-domain
+  - btk-inhibitor-biomarker
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# TBL1XR1
+
+## Overview
+
+TBL1XR1 encodes a WD40-repeat protein that is part of the NCoR/SMRT corepressor complex. Recurrent mutations are observed in B-cell lymphomas, including primary CNS lymphoma ([PCNSL](../cancer_types/PCNSL.md)), where they have emerged as a candidate predictive biomarker for BTK inhibitor response.
+
+## Alterations observed in the corpus
+
+- Missense mutations mapping to the WD40 domains, interpreted as likely loss-of-function; present in 9/25 (36%) of sequenced PCNSLs in the MSK [ibrutinib](../drugs/ibrutinib.md) phase II cohort [PMID:38995739](../papers/38995739.md).
+
+## Cancer types (linked)
+
+- [PCNSL](../cancer_types/PCNSL.md) — mutated in ~36% of PCNSLs; in the MSK ibrutinib trial, TBL1XR1-mutant PCNSLs had median PFS of 16.5 months vs 3.1 months in wild-type (log-rank p=0.0075, HR 0.29, 95%CI 0.11–0.76). In an independent 177-patient MSK cohort treated with standard of care, TBL1XR1 status was not prognostic, suggesting the association is predictive of BTK-inhibitor benefit rather than generally prognostic [PMID:38995739](../papers/38995739.md).
+
+## Co-occurrence and mutual exclusivity
+
+- Observed alongside canonical BCR-pathway drivers [MYD88](MYD88.md), [CD79B](CD79B.md), and [CARD11](CARD11.md) in the non-germinal-center [PCNSL](../cancer_types/PCNSL.md) cohort [PMID:38995739](../papers/38995739.md).
+
+## Therapeutic relevance
+
+- Candidate predictive biomarker for durable response to [ibrutinib](../drugs/ibrutinib.md) monotherapy in r/r [PCNSL](../cancer_types/PCNSL.md); generalization to second-generation BTK inhibitors such as [tirabrutinib](../drugs/tirabrutinib.md) remains an open question [PMID:38995739](../papers/38995739.md).
+
+## Open questions
+
+- Mechanism by which WD40-domain LoF sensitizes [PCNSL](../cancer_types/PCNSL.md) to BTK inhibition is not established [PMID:38995739](../papers/38995739.md).
+- Whether TBL1XR1-driven benefit generalizes beyond [ibrutinib](../drugs/ibrutinib.md) to other BTK inhibitors [PMID:38995739](../papers/38995739.md).
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/genes/TP53.md
+++ b/wiki/genes/TP53.md
@@ -1,10 +1,10 @@
 ---
 symbol: TP53
 aliases: []
-cancer_types: [CLLSLL, APAD, LCH, CHL, PTCL, LUAD, NSCLC, BLCA, UTUC]
+cancer_types: [CLLSLL, APAD, LCH, CHL, PTCL, LUAD, NSCLC, BLCA, UTUC, PAAD]
 tags: [tumor-suppressor, prognosis, aneuploidy, metastasis, resistance]
-processed_by: entity-page-writer
-processed_at: 2026-04-08
+processed_by: paper-compiler
+processed_at: 2026-04-09
 ---
 
 # TP53
@@ -28,6 +28,7 @@ TP53 is the canonical tumor suppressor and the most broadly cited gene in the cb
 - In SDH-deficient GISTs (n=26), TP53 mutations portended worse recurrence-free and disease-free survival [PMID:37477937](../papers/37477937.md).
 - TP53 clonal hematopoiesis VAFs consistently expanded at onset of subsequent hematologic malignancy in 26 MSK patients with paired post-diagnosis sequencing, consistent with preleukemic selection under therapy [PMID:38147626](../papers/38147626.md).
 - In FGFR3-altered urothelial carcinoma, TP53 is inversely associated with [FGFR3](../genes/FGFR3.md) alterations; baseline TP53 co-mutation linked to lower [erdafitinib](../drugs/erdafitinib.md) ORR (22% vs 40%) and enrichment among primary progressors (3/5); acquired TP53 mutations identified in 5/27 serial cfDNA cases as putative [erdafitinib](../drugs/erdafitinib.md) resistance drivers [PMID:37682528](../papers/37682528.md).
+- In 397 sequenced resected [PAAD](../cancer_types/PAAD.md) patients (MSK `pancreas_msk_2024`), TP53 was mutated in 71% (284/397); frequency did not differ by [KRAS](../genes/KRAS.md) allele (G12D / G12V / G12R) [PMID:39214094](../papers/39214094.md).
 
 ## Cancer types (linked)
 
@@ -38,6 +39,7 @@ TP53 is the canonical tumor suppressor and the most broadly cited gene in the cb
 - [LUAD](../cancer_types/LUAD.md) / [NSCLC](../cancer_types/NSCLC.md) — metastasis-associated driver, ctDNA-detected pathogenic alterations are independently prognostic [PMID:37084736](../papers/37084736.md) [PMID:36357680](../papers/36357680.md) [PMID:37591896](../papers/37591896.md).
 - [LCH](../cancer_types/LCH.md) / germ cell tumors — recurrently observed in rare-cancer profiling [PMID:36862133](../papers/36862133.md).
 - [BLCA](../cancer_types/BLCA.md) / [UTUC](../cancer_types/UTUC.md) — inversely associated with [FGFR3](../genes/FGFR3.md) alterations; co-mutation marks poor [erdafitinib](../drugs/erdafitinib.md) response [PMID:37682528](../papers/37682528.md).
+- [PAAD](../cancer_types/PAAD.md) — mutated in 71% of MSK resected PDAC sequenced cohort; not allele-specific across KRAS mutants [PMID:39214094](../papers/39214094.md).
 
 ## Co-occurrence and mutual exclusivity
 
@@ -70,5 +72,6 @@ TP53 is the canonical tumor suppressor and the most broadly cited gene in the cb
 - [PMID:39506116](../papers/39506116.md)
 - [PMID:37477937](../papers/37477937.md)
 - [PMID:38147626](../papers/38147626.md)
+- [PMID:39214094](../papers/39214094.md)
 
-*This page was processed by **entity-page-writer** on **2026-04-08**.*
+*This page was processed by **paper-compiler** on **2026-04-09**.*

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -32,12 +32,12 @@ Nothing is invented — unverified terms are flagged rather than canonicalized.
 
 | Section | Count | What you'll find |
 |---|---|---|
-| [Papers](papers/index.qmd) | 18 | Per-publication summaries: cohort, methods, findings, citations |
+| [Papers](papers/index.qmd) | 19 | Per-publication summaries: cohort, methods, findings, citations |
 | [Genes](genes/index.qmd) | 126 | Alterations, co-occurrence, therapeutic relevance across the corpus |
 | [Cancer types](cancer_types/index.qmd) | 42 | OncoTree-anchored disease pages linking studies and alterations |
-| [Datasets](datasets/index.qmd) | 21 | cBioPortal studies with cohort details and linked publications |
+| [Datasets](datasets/index.qmd) | 22 | cBioPortal studies with cohort details and linked publications |
 | [Drugs](drugs/index.qmd) | 35 | Targeted therapies, resistance patterns, evidence in the corpus |
-| [Methods](methods/index.qmd) | 32 | Sequencing assays, gene panels, and analytical pipelines |
+| [Methods](methods/index.qmd) | 33 | Sequencing assays, gene panels, and analytical pipelines |
 | [Themes](themes/index.qmd) | — | Cross-cutting syntheses (in progress) |
 
 ## How to read a page

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -32,12 +32,12 @@ Nothing is invented — unverified terms are flagged rather than canonicalized.
 
 | Section | Count | What you'll find |
 |---|---|---|
-| [Papers](papers/index.qmd) | 17 | Per-publication summaries: cohort, methods, findings, citations |
-| [Genes](genes/index.qmd) | 123 | Alterations, co-occurrence, therapeutic relevance across the corpus |
-| [Cancer types](cancer_types/index.qmd) | 40 | OncoTree-anchored disease pages linking studies and alterations |
-| [Datasets](datasets/index.qmd) | 20 | cBioPortal studies with cohort details and linked publications |
-| [Drugs](drugs/index.qmd) | 31 | Targeted therapies, resistance patterns, evidence in the corpus |
-| [Methods](methods/index.qmd) | 31 | Sequencing assays, gene panels, and analytical pipelines |
+| [Papers](papers/index.qmd) | 18 | Per-publication summaries: cohort, methods, findings, citations |
+| [Genes](genes/index.qmd) | 126 | Alterations, co-occurrence, therapeutic relevance across the corpus |
+| [Cancer types](cancer_types/index.qmd) | 42 | OncoTree-anchored disease pages linking studies and alterations |
+| [Datasets](datasets/index.qmd) | 21 | cBioPortal studies with cohort details and linked publications |
+| [Drugs](drugs/index.qmd) | 35 | Targeted therapies, resistance patterns, evidence in the corpus |
+| [Methods](methods/index.qmd) | 32 | Sequencing assays, gene panels, and analytical pipelines |
 | [Themes](themes/index.qmd) | — | Cross-cutting syntheses (in progress) |
 
 ## How to read a page

--- a/wiki/methods/cosmx-smi.md
+++ b/wiki/methods/cosmx-smi.md
@@ -1,0 +1,30 @@
+---
+name: NanoString CosMx SMI
+slug: cosmx-smi
+kind: method
+unverified: true
+tags: [spatial-transcriptomics, imaging, nanostring, high-plex, tma]
+processed_by: paper-compiler
+processed_at: 2026-04-09
+---
+
+# NanoString CosMx SMI
+
+## Overview
+
+NanoString CosMx Spatial Molecular Imager (SMI) is a high-plex in situ single-cell spatial profiling platform that measures RNA (and optionally protein) expression directly on formalin-fixed paraffin-embedded tissue sections, including tissue microarrays, at subcellular resolution [PMID:39214094](../papers/39214094.md).
+
+## Used by
+
+- [PMID:39214094](../papers/39214094.md) — applied to a tissue microarray of 20 [PAAD](../cancer_types/PAAD.md) patients (14 tumors, 6 normal pancreas) to profile allele-specific transcriptional programs in [KRAS](../genes/KRAS.md)-mutant PDAC, identifying enriched KRAS signaling and EMT in KRAS^G12D^ tumors versus increased TNF/NF-κB signaling in KRAS^G12R^ tumors [PMID:39214094](../papers/39214094.md).
+
+## Notes
+
+- High-plex in situ RNA profiling on FFPE / TMA sections; used here as the spatial complement to bulk RNA-seq on 100 tumors [PMID:39214094](../papers/39214094.md).
+- Corpus-grown slug; not present in canonical `schema/ontology/gene_panels.json` (CosMx is an imaging platform, not a targeted DNA panel), so marked `unverified: true`.
+
+## Sources
+
+- [PMID:39214094](../papers/39214094.md)
+
+*This page was processed by **paper-compiler** on **2026-04-09**.*

--- a/wiki/methods/msk-hemepact.md
+++ b/wiki/methods/msk-hemepact.md
@@ -1,0 +1,30 @@
+---
+name: MSK-HemePACT panel
+slug: msk-hemepact
+kind: method
+unverified: true
+tags: [msk, targeted-sequencing, panel, heme, ctdna]
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# MSK-HemePACT panel
+
+## Overview
+
+MSK-HemePACT is a Memorial Sloan Kettering targeted hybrid-capture DNA sequencing panel focused on hematologic malignancies, covering ~585 cancer-associated genes. It is the heme-focused counterpart to MSK-IMPACT and is used on tumor biopsies, matched germline, and CSF ctDNA [PMID:38995739](../papers/38995739.md).
+
+## Used by
+
+- [PMID:38995739](../papers/38995739.md) — applied to archival tumor (25/31 [PCNSL](../cancer_types/PCNSL.md)) and paired pre-/on-treatment CSF ctDNA (14 patients) in a phase I/II [ibrutinib](../drugs/ibrutinib.md) trial in r/r CNS lymphoma; identified [TBL1XR1](../genes/TBL1XR1.md) WD40-domain mutations as associated with prolonged ibrutinib PFS (16.5 vs 3.1 months, p=0.0075), and enabled CSF ctDNA kinetic analysis showing that ctDNA clearance within 4 weeks correlated with complete and long-term response [PMID:38995739](../papers/38995739.md).
+
+## Notes
+
+- ~585 cancer genes, hematologic-focused; used on both tumor tissue and CSF ctDNA with matched germline [PMID:38995739](../papers/38995739.md).
+- Corpus-grown slug; not present in canonical `schema/ontology/gene_panels.json`, so marked `unverified: true`.
+
+## Sources
+
+- [PMID:38995739](../papers/38995739.md)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/methods/msk-impact-panel.md
+++ b/wiki/methods/msk-impact-panel.md
@@ -25,6 +25,7 @@ Generic slug for MSK-IMPACT, the Memorial Sloan Kettering matched tumor/normal h
 - [PMID:38147626](../papers/38147626.md) — MSK-IMPACT sequencing contributed to the cohort analysis [PMID:38147626](../papers/38147626.md).
 - [PMID:38864854](../papers/38864854.md) — MSK-IMPACT sequencing contributed to the cohort analysis [PMID:38864854](../papers/38864854.md).
 - [PMID:38995739](../papers/38995739.md) — referenced alongside the heme-focused [MSK-HemePACT](../methods/msk-hemepact.md) panel in the phase I/II [ibrutinib](../drugs/ibrutinib.md) trial in r/r CNS lymphoma; an independent cohort of 177 MSK [PCNSL](../cancer_types/PCNSL.md) patients treated with standard of care was used to show [TBL1XR1](../genes/TBL1XR1.md) status was not prognostic under SOC, supporting its predictive (rather than prognostic) role for ibrutinib benefit [PMID:38995739](../papers/38995739.md).
+- [PMID:39214094](../papers/39214094.md) — applied to 397/1,360 resected [PAAD](../cancer_types/PAAD.md) patients in the MSK `pancreas_msk_2024` cohort with no selection criteria, producing driver-gene and [KRAS](../genes/KRAS.md)-allele calls that underpinned the stage I KRAS^G12R^ enrichment and allele-specific outcome findings; authors explicitly note that CDKN2A/B deep deletions were under-detected by IMPACT and excluded from their main analyses [PMID:39214094](../papers/39214094.md).
 
 ## Notes
 
@@ -42,5 +43,6 @@ Generic slug for MSK-IMPACT, the Memorial Sloan Kettering matched tumor/normal h
 - [PMID:38147626](../papers/38147626.md)
 - [PMID:38864854](../papers/38864854.md)
 - [PMID:38995739](../papers/38995739.md)
+- [PMID:39214094](../papers/39214094.md)
 
-*This page was processed by **crosslinker** on **2026-04-09**.*
+*This page was processed by **paper-compiler** on **2026-04-09**.*

--- a/wiki/methods/msk-impact-panel.md
+++ b/wiki/methods/msk-impact-panel.md
@@ -4,8 +4,8 @@ slug: msk-impact-panel
 kind: method
 unverified: true
 tags: [msk-impact, targeted-sequencing, panel]
-processed_by: entity-page-writer
-processed_at: 2026-04-08
+processed_by: crosslinker
+processed_at: 2026-04-09
 ---
 
 # MSK-IMPACT panel (generic)
@@ -24,6 +24,7 @@ Generic slug for MSK-IMPACT, the Memorial Sloan Kettering matched tumor/normal h
 - [PMID:37477937](../papers/37477937.md) — MSK-IMPACT sequencing contributed to the cohort analysis [PMID:37477937](../papers/37477937.md).
 - [PMID:38147626](../papers/38147626.md) — MSK-IMPACT sequencing contributed to the cohort analysis [PMID:38147626](../papers/38147626.md).
 - [PMID:38864854](../papers/38864854.md) — MSK-IMPACT sequencing contributed to the cohort analysis [PMID:38864854](../papers/38864854.md).
+- [PMID:38995739](../papers/38995739.md) — referenced alongside the heme-focused [MSK-HemePACT](../methods/msk-hemepact.md) panel in the phase I/II [ibrutinib](../drugs/ibrutinib.md) trial in r/r CNS lymphoma; an independent cohort of 177 MSK [PCNSL](../cancer_types/PCNSL.md) patients treated with standard of care was used to show [TBL1XR1](../genes/TBL1XR1.md) status was not prognostic under SOC, supporting its predictive (rather than prognostic) role for ibrutinib benefit [PMID:38995739](../papers/38995739.md).
 
 ## Notes
 
@@ -40,5 +41,6 @@ Generic slug for MSK-IMPACT, the Memorial Sloan Kettering matched tumor/normal h
 - [PMID:37477937](../papers/37477937.md)
 - [PMID:38147626](../papers/38147626.md)
 - [PMID:38864854](../papers/38864854.md)
+- [PMID:38995739](../papers/38995739.md)
 
-*This page was processed by **entity-page-writer** on **2026-04-08**.*
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/papers/38995739.md
+++ b/wiki/papers/38995739.md
@@ -1,0 +1,114 @@
+---
+pmid: 38995739
+pmcid: PMC11398981
+study_id: pcnsl_msk_2024
+doi: 10.1158/1078-0432.CCR-24-0605
+title: "A Phase II study assessing Long-Term Response to Ibrutinib Monotherapy in recurrent or refractory CNS Lymphoma"
+authors:
+  - Christian Grommes
+  - Subhiksha Nandakumar
+  - Lauren R. Schaff
+  - Igor Gavrilovic
+  - Thomas J. Kaley
+  - Craig P. Nolan
+  - Nikolaus Schultz
+  - Lisa M. DeAngelis
+  - Ingo K. Mellinghoff
+journal: Clinical Cancer Research
+year: 2024
+cancer_types:
+  - PCNSL
+  - DLBCLNOS
+genes:
+  - TBL1XR1
+  - MYD88
+  - CD79B
+  - CARD11
+datasets:
+  - pcnsl_msk_2024
+drugs:
+  - ibrutinib
+  - tirabrutinib
+  - methotrexate
+  - temozolomide
+  - temsirolimus
+  - lenalidomide
+  - pembrolizumab
+methods:
+  - msk-hemepact
+  - msk-impact-panel
+tags:
+  - phase-ii-trial
+  - btk-inhibitor
+  - cns-lymphoma
+  - csf-ctdna
+  - biomarker
+  - long-term-response
+processed_by: crosslinker
+processed_at: 2026-04-09
+---
+
+# A Phase II study assessing Long-Term Response to Ibrutinib Monotherapy in recurrent or refractory CNS Lymphoma
+
+**PMID:** 38995739 · **DOI:** 10.1158/1078-0432.CCR-24-0605 · **Journal:** Clinical Cancer Research (2024)
+
+## TL;DR
+
+This single-center phase I/II trial (NCT02315326) at MSK treated 46 patients with relapsed/refractory primary ([PCNSL](../cancer_types/PCNSL.md), n=31) or secondary (SCNSL, n=15) CNS lymphoma with single-agent [ibrutinib](../drugs/ibrutinib.md) (mostly 840 mg/day). Response rates were 74% in PCNSL (12 CRs) and 60% in SCNSL (7 CRs), with ~10% of patients achieving durable (>3 year) responses. Exploratory genomic analysis using the [MSK-HemePACT](../methods/msk-hemepact.md) panel on archival tumor and paired CSF identified [TBL1XR1](../genes/TBL1XR1.md) mutations as associated with significantly longer PFS on ibrutinib (16.5 vs 3.1 months, p=0.0075), and CSF ctDNA clearance within 4 weeks correlated with complete and long-term response [PMID:38995739](../papers/38995739.md).
+
+## Cohort & data
+
+- 46 patients with r/r CNS lymphoma: 31 [PCNSL](../cancer_types/PCNSL.md) + 15 SCNSL; median age 68 (range 21–90); median 2 prior therapies; all previously received [methotrexate](../drugs/methotrexate.md) [PMID:38995739](../papers/38995739.md).
+- Single-center investigator-initiated trial at Memorial Sloan Kettering (NCT02315326); 3 patients dosed at 560 mg, 43 at 840 mg daily.
+- Median follow-up 49.9 months (PCNSL) and 62.1 months (SCNSL).
+- Archival tumor biopsies available in 25/31 PCNSL cases; paired pre-/on-treatment CSF (CSF1/CSF2) available for 14 patients.
+- Sequencing: [MSK-HemePACT](../methods/msk-hemepact.md) targeted panel (585 cancer genes, hematologic-focused) on tumor and CSF ctDNA; matched germline.
+- Data deposited in cBioPortal as study [pcnsl_msk_2024](../datasets/pcnsl_msk_2024.md).
+
+## Key findings
+
+- **[PCNSL](../cancer_types/PCNSL.md) response:** 23/31 (74%) responded, including 12 CR and 11 PR. Median PFS 4.5 months (95%CI 2.8–9.2); 1y-PFS 23.7%, 2y 13.5%, 3y 10.1%. Median OS 25.4 months. Median DOR 5.5 months [PMID:38995739](../papers/38995739.md).
+- **SCNSL response:** 9/15 (60%) responded, including 7 CR. Median PFS 5.3 months (95%CI 1.3–14.5); 1y-PFS 31.1%, 3y-PFS 20.7%. Median DOR 8.7 months.
+- **Long-term responders:** 5/46 (~11%) had ongoing responses >3 years on single-agent [ibrutinib](../drugs/ibrutinib.md).
+- **[TBL1XR1](../genes/TBL1XR1.md) and response:** PCNSLs with TBL1XR1 mutations (9 patients) had PFS 16.5 months (95%CI 2.5–40.0) vs 3.1 months (95%CI 2.5–4.5) in wild-type (log-rank p=0.0075, HR 0.29, 95%CI 0.11–0.76). All TBL1XR1 mutations mapped to WD40 domains, likely loss-of-function.
+- **TBL1XR1 not prognostic under SOC:** In an independent cohort of 177 MSK PCNSLs treated with standard of care, TBL1XR1 status was not associated with outcome, suggesting predictive rather than prognostic value for ibrutinib.
+- **[MYD88](../genes/MYD88.md) mutations:** Associated with longer PFS on ibrutinib (9.2 vs 2.9 months; p=0.027, HR 0.39).
+- **[CARD11](../genes/CARD11.md) mutations:** 6 patients; associated with shorter PFS (2.2 vs 5.5 months), consistent with prior reports of CARD11-mediated ibrutinib resistance in B-cell malignancies.
+- **BCR pathway landscape in PCNSL cohort:** MYD88 72%, [CD79B](../genes/CD79B.md) 48%, CARD11 24%, TBL1XR1 36%; 21/25 (84%) non-germinal center (Hans classifier).
+- **CSF ctDNA kinetics:** Paired CSF1/CSF2 in 14 patients. Complete ctDNA clearance within 4 weeks in 8/14 (57%); 3/14 reduced; 3/14 unchanged. Patients achieving CR on imaging had undetectable ctDNA at week 4, while 67% of non-CR patients had persistent ctDNA. Patients with PFS ≥6 months had a median 100% reduction in ctDNA alterations vs 30.8% for PFS <6 months (p=0.018).
+- **Pharmacokinetics:** Peak plasma ibrutinib ~191.7 ng/mL at 2h; CSF concentration 1.386 ng/mL (3 nM) at 560 mg and 2.695 ng/mL (6 nM) at 840 mg. Plasma level correlated with CSF level.
+- **Safety:** No grade 5 events; no treatment-related deaths. Most common AEs: thrombocytopenia (83%), hyperglycemia (57%), hypercholesterolemia (48%), ALT elevation (48%). One case of aspergillosis in a heavily corticosteroid-pretreated patient.
+
+## Genes & alterations
+
+- [TBL1XR1](../genes/TBL1XR1.md) — WD40-domain mutations (likely LoF); present in 36% of PCNSLs; predictive of prolonged [ibrutinib](../drugs/ibrutinib.md) response (PFS 16.5 vs 3.1 months, p=0.0075) [PMID:38995739](../papers/38995739.md).
+- [MYD88](../genes/MYD88.md) — mutated in 72% of [PCNSL](../cancer_types/PCNSL.md) cohort; associated with longer PFS on ibrutinib (9.2 vs 2.9 months, p=0.027).
+- [CD79B](../genes/CD79B.md) — mutated in 48% of PCNSL cohort; canonical BCR-pathway driver in PCNSL.
+- [CARD11](../genes/CARD11.md) — mutated in 24% of PCNSL; coiled-coil-domain mutations associated with poor response and shorter PFS (2.2 vs 5.5 months), consistent with known ibrutinib-resistance mechanism in DLBCL.
+
+## Clinical implications
+
+- Single-agent [ibrutinib](../drugs/ibrutinib.md) 840 mg daily is active and tolerable in heavily pretreated r/r [PCNSL](../cancer_types/PCNSL.md) and secondary CNS lymphoma, supporting its inclusion in NCCN r/r PCNSL guidelines [PMID:38995739](../papers/38995739.md).
+- [TBL1XR1](../genes/TBL1XR1.md) mutation status is a candidate predictive biomarker for durable benefit from BTK inhibition in PCNSL; warrants prospective validation with second-generation BTK inhibitors.
+- [CARD11](../genes/CARD11.md) coiled-coil mutations mark likely primary ibrutinib resistance.
+- Paired pre- and on-treatment CSF liquid biopsy using the [MSK-HemePACT](../methods/msk-hemepact.md) panel enables early assessment of response; clearance of CSF ctDNA within 4 weeks is a candidate surrogate for complete and durable response.
+- Consider fungal surveillance (BD-glucan, galactomannan) in patients on chronic corticosteroids receiving ibrutinib.
+
+## Limitations & open questions
+
+- Single-center, non-randomized trial; modest sample size (n=46) limits the statistical weight of biomarker associations — authors explicitly frame [TBL1XR1](../genes/TBL1XR1.md)/[MYD88](../genes/MYD88.md)/[CARD11](../genes/CARD11.md) findings as exploratory.
+- Archival tumor tissue was unavailable in 6/31 [PCNSL](../cancer_types/PCNSL.md) and many patients lacked rebiopsy at recurrence, so resistance mechanisms at progression are under-sampled.
+- Only 14 patients had paired CSF1/CSF2 samples for ctDNA kinetic analysis.
+- SCNSL cohort is heterogeneous (n=15) and underpowered for genomic subgroup analysis.
+- Dose comparison between 560 mg and 840 mg is confounded by small 560 mg subset (n=3).
+- Whether TBL1XR1-driven benefit generalizes to second-generation BTK inhibitors (e.g., [tirabrutinib](../drugs/tirabrutinib.md)) is an open question the authors flag for ongoing trials.
+
+## Citations from this paper used in the wiki
+
+- "Tumor responses were observed in 23/31 (74%) PCNSLs and 9/15 (60%) SCNSLs, including 12 complete responses in PCNSL and 7 in SCNSL." (Abstract)
+- "PCNSL patients with alterations in TBL1XR1 had a significantly longer progression-free survival of 16.5 months (95%CI: 2.5–40.0) compared to 3.1 months (95%CI: 2.5–4.5)… (Log-rank p=0.0075, HR: 0.29, 95%CI: 0.11–0.76)." (Results)
+- "All TBL1XR1 mutations mapped to its WD40 domains… and most likely represent loss of function events." (Results)
+- "In patients with a complete response, ctDNA could no longer be detected after 4 weeks of ibrutinib therapy." (Results)
+- "The data generated in this study are publicly available in cBioPortal for Cancer Genomics at https://www.cbioportal.org/study/summary?id=pcnsl_msk_2024" (Data Availability)
+
+*This page was processed by **crosslinker** on **2026-04-09**.*

--- a/wiki/papers/39214094.md
+++ b/wiki/papers/39214094.md
@@ -1,0 +1,94 @@
+---
+pmid: 39214094
+pmcid: PMC11419252
+study_id: pancreas_msk_2024
+doi: 10.1016/j.ccell.2024.08.002
+title: "Distinct clinical outcomes and biological features of specific KRAS mutants in human pancreatic cancer"
+authors:
+  - Caitlin A. McIntyre
+  - Adrien Grimont
+  - Jiwoon Park
+  - Henry Walch
+  - Nikolaus Schultz
+  - Lukas E. Dow
+  - William R. Jarnagin
+  - Rohit Chandwani
+journal: Cancer Cell
+year: 2024
+cancer_types:
+  - PAAD
+genes:
+  - KRAS
+  - TP53
+  - CDKN2A
+  - SMAD4
+datasets:
+  - pancreas_msk_2024
+drugs:
+  - fluorouracil
+  - irinotecan
+  - oxaliplatin
+methods:
+  - msk-impact-panel
+  - cosmx-smi
+tags:
+  - kras-alleles
+  - pdac
+  - early-stage
+  - spatial-transcriptomics
+  - prognosis
+  - organoids
+processed_by: paper-compiler
+processed_at: 2026-04-09
+---
+
+# Distinct clinical outcomes and biological features of specific KRAS mutants in human pancreatic cancer
+
+## TL;DR
+
+In a consecutive MSK cohort of 1,360 resected PDAC patients, KRAS^G12R^ is enriched in stage I disease, associated with increased node-negativity, decreased distant recurrence, and improved overall survival relative to KRAS^G12D^. Spatial profiling (NanoString CosMx SMI, n=20) and bulk RNA-seq (n=100) reveal enhanced oncogenic KRAS signaling and EMT in KRAS^G12D^ versus increased TNF/NF-κB signaling in KRAS^G12R^ tumors, and isogenic Kras^mut^;Trp53^KO^ mouse organoids recapitulate the reduced migratory / improved survival phenotype orthotopically.
+
+## Cohort & data
+
+- 1,360 consecutive PDAC patients undergoing surgical resection at Memorial Sloan Kettering between April 2004 and April 2019; 397 (29%) stage I, 963 (71%) stage II–III [PMID:39214094](../papers/39214094.md).
+- 397 patients with targeted tumor sequencing on [MSK-IMPACT](../methods/msk-impact-panel.md) (103 stage I, 294 stage II–III); no selection criteria applied [PMID:39214094](../papers/39214094.md).
+- Bulk RNA-seq on 100 resected tumors; high-plex spatial profiling on 20 patients (14 tumors, 6 normal pancreas) using NanoString [CosMx SMI](../methods/cosmx-smi.md) on tissue microarrays [PMID:39214094](../papers/39214094.md).
+- Isogenic mouse Kras^G12D/+^;Trp53^KO^ and Kras^G12R/+^;Trp53^KO^ pancreatic organoids used for in vitro and orthotopic transplantation studies [PMID:39214094](../papers/39214094.md).
+- Genomic and clinical data released as cBioPortal study `pancreas_msk_2024`; external ICGC-PACA (`paad_icgc`) cohort used for validation via cBioPortal [PMID:39214094](../papers/39214094.md).
+
+## Key findings
+
+- KRAS altered in 361/397 (90%), [TP53](../genes/TP53.md) in 284 (71%), [CDKN2A](../genes/CDKN2A.md) in 95 (24%), [SMAD4](../genes/SMAD4.md) in 68 (17%); no significant difference in overall driver-gene frequencies between early- and late-stage disease after multiple-testing correction [PMID:39214094](../papers/39214094.md).
+- KRAS allele distribution: G12D 36.5%, G12V 32.5%, G12R 13.9%, other 8.1%, WT 9.1%; KRAS^G12R^ enriched in stage I disease (23% vs 11% in stage II–III, p=0.022) [PMID:39214094](../papers/39214094.md).
+- KRAS^G12R^ tumors are more often node-negative than KRAS^G12D^ (47% vs 26%, p=0.019) without a difference in T-stage, so stage migration is driven by reduced nodal spread rather than smaller primary size [PMID:39214094](../papers/39214094.md).
+- Patients with KRAS^G12R^ PDAC were more likely to have a family history of pancreatic cancer (16.4% vs 4.2%, p=0.003) and tended to be non-smokers [PMID:39214094](../papers/39214094.md).
+- KRAS^G12R^ tumors carried a higher proportion of [CDKN2A](../genes/CDKN2A.md) mutations than KRAS^G12D^ (40% vs 22.1%, p=0.046); TP53 and SMAD4 frequencies were not allele-dependent [PMID:39214094](../papers/39214094.md).
+- Over time, KRAS^G12R^ disease is associated with improved overall survival and decreased distant recurrence, but a higher rate of local recurrence compared to KRAS^G12D^; KRAS^G12V^ also shows improved OS but without the early-stage enrichment [PMID:39214094](../papers/39214094.md).
+- Bulk RNA-seq and [CosMx SMI](../methods/cosmx-smi.md) spatial profiling show enriched KRAS signaling and epithelial–mesenchymal transition (EMT) in KRAS^G12D^ tumors versus increased TNF/NF-κB signaling in KRAS^G12R^ tumors [PMID:39214094](../papers/39214094.md).
+- Isogenic Kras^G12D/+^;Trp53^KO^ vs Kras^G12R/+^;Trp53^KO^ organoids recapitulate the transcriptional divergence; orthotopic transplantation shows decreased migratory potential and improved survival for Kras^G12R^ [PMID:39214094](../papers/39214094.md).
+
+## Genes & alterations
+
+- [KRAS](../genes/KRAS.md) — PDAC allele-specific biology: G12R is prognostically favorable (early-stage, node-negative, longer OS, less distant recurrence) while G12D drives canonical oncogenic KRAS / EMT programs [PMID:39214094](../papers/39214094.md).
+- [TP53](../genes/TP53.md) — mutated in 71% of sequenced PDAC; frequency not different by KRAS allele [PMID:39214094](../papers/39214094.md).
+- [CDKN2A](../genes/CDKN2A.md) — mutated in 24% overall but enriched in KRAS^G12R^ tumors (40% vs 22.1% in G12D, p=0.046) [PMID:39214094](../papers/39214094.md).
+- [SMAD4](../genes/SMAD4.md) — mutated in 17% of sequenced PDAC; frequency not different by KRAS allele [PMID:39214094](../papers/39214094.md).
+
+## Clinical implications
+
+- KRAS allele should be considered when interpreting stage and recurrence risk in resected PDAC: KRAS^G12R^ identifies a subset with better intrinsic prognosis that may preferentially benefit from local control strategies, given the relative increase in local versus distant recurrence [PMID:39214094](../papers/39214094.md).
+- Enrichment of KRAS^G12R^ among resected patients who received neoadjuvant [fluorouracil](../drugs/fluorouracil.md)-based chemotherapy (most frequently FOLFIRINOX with [irinotecan](../drugs/irinotecan.md) and [oxaliplatin](../drugs/oxaliplatin.md)) is consistent with a higher probability of response rather than selection for borderline-resectable disease, though the trend did not reach statistical significance [PMID:39214094](../papers/39214094.md).
+- Allele-specific transcriptional programs (NF-κB in G12R vs KRAS/EMT in G12D) suggest divergent actionable dependencies across KRAS-mutant PDAC rather than a single pan-KRAS therapeutic strategy [PMID:39214094](../papers/39214094.md).
+
+## Limitations & open questions
+
+- Sequencing cohort (n=397) is a subset of the full 1,360 resected cohort; MSK-IMPACT targets a fixed gene panel and the frequency of CDKN2A/B deletions detected was low, so deletion events are incompletely captured [PMID:39214094](../papers/39214094.md).
+- Spatial profiling (n=20) and bulk RNA-seq (n=100) sample sizes are modest; allele-specific transcriptional differences are internally consistent but require external validation [PMID:39214094](../papers/39214094.md).
+- Mechanistic basis for the reduced metastatic propensity of KRAS^G12R^ organoids beyond NF-κB / EMT axis remains to be resolved [PMID:39214094](../papers/39214094.md).
+- Single-institution, surgically-resected cohort — findings may not generalize to unresectable or metastatic PDAC presentations [PMID:39214094](../papers/39214094.md).
+
+## Citations from this paper used in the wiki
+
+- [PMID:39214094](../papers/39214094.md)
+
+*This page was processed by **paper-compiler** on **2026-04-09**.*


### PR DESCRIPTION
## Summary

- **Obsidian CLI integration**: Added `docs/obsidian-cli.md` cheat sheet and updated all agent defs (`paper-compiler`, `entity-page-writer`, `crosslinker`) to use `obsidian vault=wiki …` for token-efficient wiki reads instead of full-file `Read`/`Grep`/`Glob`
- **Three key wins**: (1) `reload` after Write to keep CLI index fresh, (2) outline-guided narrow Reads for merge-append edits (~1-2k tokens vs 5-20k), (3) synced all agent defs to the new CLI flow
- **Two new papers processed**: PMID 38995739 (PCNSL MSK cohort) and PMID 39214094 (MSK PDAC KRAS-allele cohort), with 15 new/updated entity pages
- **Linter fix**: orphan check now respects per-section Quarto `index.qmd` listings (`contents: "*.md"`)

## Commits

1. `112e297` — Obsidian CLI docs + CLAUDE.md rules
2. `a8c1ece` — Paper 38995739 (PCNSL MSK cohort) + entity pages
3. `6433148` — Refresh wiki/index.md section counts
4. `33226d0` — Fix orphan lint: respect per-section Quarto listings
5. `e2f82d4` — Paper 39214094 (MSK PDAC KRAS-allele cohort) + entity pages
6. `5c04b25` — Capture remaining CLI wins in agent defs and docs

## Test plan

- [ ] `uv run cbio-kb lint --wiki-dir wiki` passes clean
- [ ] Post-merge from main checkout: process one unprocessed paper and verify `obsidian vault=wiki reload` makes the new page immediately queryable via CLI
- [ ] Verify narrow-Read pattern produces <30-line slices on entity merge-appends

🤖 Generated with [Claude Code](https://claude.com/claude-code)