### PR TITLE
feat(ontology): add cancer_type.main_type + require oncotree_code

### DIFF
--- a/schema/templates/cancer_type.md
+++ b/schema/templates/cancer_type.md
@@ -1,6 +1,7 @@
 ---
 name:
 oncotree_code:
+main_type:
 parent:
 tags: []
 processed_by:

--- a/src/cbio_kb/wiki/lint.py
+++ b/src/cbio_kb/wiki/lint.py
@@ -13,7 +13,7 @@ from cbio_kb.wiki.vault import _parse_frontmatter, _LINK_RE as LINK_RE, _FRONTMA
 REQUIRED_FRONTMATTER = {
     "papers": {"pmid", "title"},
     "genes": {"symbol"},
-    "cancer_types": {"name"},
+    "cancer_types": {"name", "oncotree_code"},
     "datasets": {"name"},
     "drugs": {"name"},
     "methods": {"name"},

--- a/wiki/cancer_types/ACYC.md
+++ b/wiki/cancer_types/ACYC.md
@@ -1,11 +1,11 @@
 ---
 name: Adenoid Cystic Carcinoma
 oncotree_code: ACYC
+main_type: Salivary Gland Cancer
 parent: SACA
 tags: [rare-cancers, salivary-gland]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Salivary Gland Cancer
 ---
 
 # Adenoid Cystic Carcinoma (ACYC)

--- a/wiki/cancer_types/AITL.md
+++ b/wiki/cancer_types/AITL.md
@@ -1,11 +1,11 @@
 ---
 name: Angioimmunoblastic T-Cell Lymphoma
 oncotree_code: AITL
+main_type: Mature T and NK Neoplasms
 parent: MTNN
 tags: [lymphoma, t-cell]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Mature T and NK Neoplasms
 ---
 
 # Angioimmunoblastic T-Cell Lymphoma (AITL)

--- a/wiki/cancer_types/ALCL.md
+++ b/wiki/cancer_types/ALCL.md
@@ -1,11 +1,11 @@
 ---
 name: Anaplastic Large Cell Lymphoma
 oncotree_code: ALCL
+main_type: Mature T and NK Neoplasms
 parent: MTNN
 tags: [lymphoma, t-cell]
 processed_by: crosslinker
 processed_at: 2026-04-10
-main_type: Mature T and NK Neoplasms
 ---
 
 # Anaplastic Large Cell Lymphoma (ALCL)

--- a/wiki/cancer_types/ALCLALKN.md
+++ b/wiki/cancer_types/ALCLALKN.md
@@ -1,11 +1,11 @@
 ---
 name: Anaplastic Large-Cell Lymphoma ALK Negative
 oncotree_code: ALCLALKN
+main_type: Mature T and NK Neoplasms
 parent: ALCL
 tags: [lymphoma, t-cell]
 processed_by: crosslinker
 processed_at: 2026-04-10
-main_type: Mature T and NK Neoplasms
 ---
 
 # Anaplastic Large-Cell Lymphoma ALK Negative (ALCLALKN)

--- a/wiki/cancer_types/ALCLALKP.md
+++ b/wiki/cancer_types/ALCLALKP.md
@@ -1,11 +1,11 @@
 ---
 name: Anaplastic Large-Cell Lymphoma ALK Positive
 oncotree_code: ALCLALKP
+main_type: Mature T and NK Neoplasms
 parent: ALCL
 tags: [lymphoma, t-cell]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Mature T and NK Neoplasms
 ---
 
 # Anaplastic Large-Cell Lymphoma ALK Positive (ALCLALKP)

--- a/wiki/cancer_types/ANGS.md
+++ b/wiki/cancer_types/ANGS.md
@@ -1,6 +1,7 @@
 ---
 name: Angiosarcoma
 oncotree_code: ANGS
+main_type: Soft Tissue Sarcoma
 parent: SOFT_TISSUE
 tags: [radiation-associated-sarcoma, vascular-tumor]
 processed_by: crosslinker

--- a/wiki/cancer_types/APAD.md
+++ b/wiki/cancer_types/APAD.md
@@ -1,11 +1,11 @@
 ---
 name: Appendiceal Adenocarcinoma
 oncotree_code: APAD
+main_type: Appendiceal Cancer
 parent: BOWEL
 tags: [rare-cancers, gi-oncology]
 processed_by: crosslinker
 processed_at: 2026-04-10
-main_type: Appendiceal Cancer
 ---
 
 # Appendiceal Adenocarcinoma (APAD)

--- a/wiki/cancer_types/ARMS.md
+++ b/wiki/cancer_types/ARMS.md
@@ -1,11 +1,11 @@
 ---
 name: Alveolar Rhabdomyosarcoma
 oncotree_code: ARMS
+main_type: Soft Tissue Sarcoma
 parent: RMS
 tags: [sarcoma, pediatric, rhabdomyosarcoma]
 processed_by: crosslinker
 processed_at: 2026-04-11
-main_type: Soft Tissue Sarcoma
 ---
 
 # Alveolar Rhabdomyosarcoma (ARMS)

--- a/wiki/cancer_types/ASTR.md
+++ b/wiki/cancer_types/ASTR.md
@@ -1,6 +1,7 @@
 ---
-name: "Astrocytoma, IDH-Mutant"
+name: Astrocytoma, IDH-Mutant
 oncotree_code: ASTR
+main_type: Glioma
 parent: ADIFG
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/BLCA.md
+++ b/wiki/cancer_types/BLCA.md
@@ -1,10 +1,9 @@
 ---
 name: Bladder Urothelial Carcinoma
 oncotree_code: BLCA
+main_type: Bladder Cancer
 parent: BLADDER
-tags:
-  - urothelial
-  - fgfr3
+tags: [urothelial, fgfr3]
 processed_by: entity-page-writer
 processed_at: 2026-04-15
 ---

--- a/wiki/cancer_types/BLLKMT2A.md
+++ b/wiki/cancer_types/BLLKMT2A.md
@@ -1,6 +1,7 @@
 ---
 name: B-Lymphoblastic Leukemia/Lymphoma with t(v;11q23.3);KMT2A Rearranged
 oncotree_code: BLLKMT2A
+main_type: B-Lymphoblastic Leukemia/Lymphoma
 parent: BLLRGA
 tags: [pediatric, hematologic-malignancy, MLL-rearranged]
 processed_by: crosslinker

--- a/wiki/cancer_types/BRCA.md
+++ b/wiki/cancer_types/BRCA.md
@@ -1,6 +1,7 @@
 ---
 name: Invasive Breast Carcinoma
 oncotree_code: BRCA
+main_type: Breast Cancer
 parent: BREAST
 tags: [breast]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/CESC.md
+++ b/wiki/cancer_types/CESC.md
@@ -1,6 +1,7 @@
 ---
-name: "Cervical Squamous Cell Carcinoma"
+name: Cervical Squamous Cell Carcinoma
 oncotree_code: CESC
+main_type: Cervical Cancer
 parent: CERVIX
 tags: []
 processed_by: entity-page-writer

--- a/wiki/cancer_types/CHL.md
+++ b/wiki/cancer_types/CHL.md
@@ -1,11 +1,11 @@
 ---
 name: Classical Hodgkin Lymphoma
 oncotree_code: CHL
+main_type: Hodgkin Lymphoma
 parent: HL
 tags: [lymphoma, hodgkin]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Hodgkin Lymphoma
 ---
 
 # Classical Hodgkin Lymphoma (CHL)

--- a/wiki/cancer_types/CLLSLL.md
+++ b/wiki/cancer_types/CLLSLL.md
@@ -1,11 +1,11 @@
 ---
 name: Chronic Lymphocytic Leukemia/Small Lymphocytic Lymphoma
 oncotree_code: CLLSLL
+main_type: Mature B-Cell Neoplasms
 parent: MBN
 tags: [cll, b-cell, leukemia]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Mature B-Cell Neoplasms
 ---
 
 # Chronic Lymphocytic Leukemia/Small Lymphocytic Lymphoma (CLLSLL)

--- a/wiki/cancer_types/COAD.md
+++ b/wiki/cancer_types/COAD.md
@@ -1,11 +1,11 @@
 ---
 name: Colon Adenocarcinoma
 oncotree_code: COAD
+main_type: Colorectal Cancer
 parent: COADREAD
 tags: [colorectal, gi-oncology]
 processed_by: entity-page-writer
 processed_at: 2026-04-15
-main_type: Colorectal Cancer
 ---
 
 # Colon Adenocarcinoma (COAD)

--- a/wiki/cancer_types/COADREAD.md
+++ b/wiki/cancer_types/COADREAD.md
@@ -1,6 +1,7 @@
 ---
 name: Colorectal Adenocarcinoma
 oncotree_code: COADREAD
+main_type: Colorectal Cancer
 parent: BOWEL
 tags: []
 processed_by: entity-page-writer

--- a/wiki/cancer_types/CSCC.md
+++ b/wiki/cancer_types/CSCC.md
@@ -1,6 +1,7 @@
 ---
-name: "Cutaneous Squamous Cell Carcinoma"
+name: Cutaneous Squamous Cell Carcinoma
 oncotree_code: CSCC
+main_type: Skin Cancer, Non-Melanoma
 parent: SKIN
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/CUP.md
+++ b/wiki/cancer_types/CUP.md
@@ -1,10 +1,11 @@
 ---
-name: "Cancer of Unknown Primary"
+name: Cancer of Unknown Primary
 oncotree_code: CUP
+main_type: Cancer of Unknown Primary
 parent: OTHER
 tags: []
 processed_by: entity-page-writer
-processed_at: "2026-04-11"
+processed_at: 2026-04-11
 ---
 
 # Cancer of Unknown Primary (CUP)

--- a/wiki/cancer_types/DIFG.md
+++ b/wiki/cancer_types/DIFG.md
@@ -1,6 +1,7 @@
 ---
 name: Diffuse Glioma
 oncotree_code: DIFG
+main_type: Glioma
 parent: GLIOMA
 tags: [glioma, cns]
 processed_by: crosslinker

--- a/wiki/cancer_types/DLBCLNOS.md
+++ b/wiki/cancer_types/DLBCLNOS.md
@@ -1,9 +1,9 @@
 ---
 name: Diffuse Large B-Cell Lymphoma NOS
 oncotree_code: DLBCLNOS
+main_type: Mature B-Cell Neoplasms
 parent: BLL
-tags:
-  - b-cell-lymphoma
+tags: [b-cell-lymphoma]
 processed_by: entity-page-writer
 processed_at: 2026-04-11
 ---

--- a/wiki/cancer_types/DMG.md
+++ b/wiki/cancer_types/DMG.md
@@ -1,6 +1,7 @@
 ---
-name: "Diffuse Midline Glioma, H3 K27-Altered"
+name: Diffuse Midline Glioma, H3 K27-Altered
 oncotree_code: DMG
+main_type: Gliomas, Glioneuronal Tumors, and Neuronal Tumors
 parent: PDIFHG
 tags: [pediatric, glioma, radiation, intra-tumoral-heterogeneity]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/EATL.md
+++ b/wiki/cancer_types/EATL.md
@@ -1,11 +1,11 @@
 ---
 name: Enteropathy-Associated T-Cell Lymphoma
 oncotree_code: EATL
+main_type: Mature T and NK Neoplasms
 parent: MTNN
 tags: [lymphoma, t-cell, intestinal]
 processed_by: crosslinker
 processed_at: 2026-04-10
-main_type: Mature T and NK Neoplasms
 ---
 
 # Enteropathy-Associated T-Cell Lymphoma (EATL)

--- a/wiki/cancer_types/ECD.md
+++ b/wiki/cancer_types/ECD.md
@@ -1,11 +1,11 @@
 ---
 name: Erdheim-Chester Disease
 oncotree_code: ECD
+main_type: Histiocytosis
 parent: HDCN
 tags: [histiocytosis, rare-cancers]
 processed_by: crosslinker
 processed_at: 2026-04-11
-main_type: Histiocytosis
 ---
 
 # Erdheim-Chester Disease (ECD)

--- a/wiki/cancer_types/EGC.md
+++ b/wiki/cancer_types/EGC.md
@@ -1,6 +1,7 @@
 ---
-name: "Esophagogastric Adenocarcinoma"
+name: Esophagogastric Adenocarcinoma
 oncotree_code: EGC
+main_type: Esophagogastric Cancer
 parent: STOMACH
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/EHCH.md
+++ b/wiki/cancer_types/EHCH.md
@@ -1,6 +1,7 @@
 ---
 name: Extrahepatic Cholangiocarcinoma
 oncotree_code: EHCH
+main_type: Hepatobiliary Cancer
 parent: CHOL
 tags: [biliary, hepatobiliary]
 processed_by: crosslinker

--- a/wiki/cancer_types/ERMS.md
+++ b/wiki/cancer_types/ERMS.md
@@ -1,11 +1,11 @@
 ---
 name: Embryonal Rhabdomyosarcoma
 oncotree_code: ERMS
+main_type: Soft Tissue Sarcoma
 parent: RMS
 tags: [sarcoma, pediatric, rhabdomyosarcoma]
 processed_by: entity-page-writer
 processed_at: 2026-04-11
-main_type: Soft Tissue Sarcoma
 ---
 
 # Embryonal Rhabdomyosarcoma (ERMS)

--- a/wiki/cancer_types/ESCA.md
+++ b/wiki/cancer_types/ESCA.md
@@ -1,6 +1,7 @@
 ---
-name: "Esophageal Adenocarcinoma"
+name: Esophageal Adenocarcinoma
 oncotree_code: ESCA
+main_type: Esophagogastric Cancer
 parent: EGC
 tags: []
 processed_by: entity-page-writer

--- a/wiki/cancer_types/GB.md
+++ b/wiki/cancer_types/GB.md
@@ -1,6 +1,7 @@
 ---
-name: "Glioblastoma, IDH-Wildtype"
+name: Glioblastoma, IDH-Wildtype
 oncotree_code: GB
+main_type: Glioma
 parent: ADIFG
 tags: []
 processed_by: entity-page-writer

--- a/wiki/cancer_types/GBC.md
+++ b/wiki/cancer_types/GBC.md
@@ -1,6 +1,7 @@
 ---
 name: Gallbladder Cancer
 oncotree_code: GBC
+main_type: Hepatobiliary Cancer
 parent: BILIARY_TRACT
 tags: [biliary, hepatobiliary]
 processed_by: crosslinker

--- a/wiki/cancer_types/GEJ.md
+++ b/wiki/cancer_types/GEJ.md
@@ -1,6 +1,7 @@
 ---
-name: "Adenocarcinoma of the Gastroesophageal Junction"
+name: Adenocarcinoma of the Gastroesophageal Junction
 oncotree_code: GEJ
+main_type: Esophagogastric Cancer
 parent: EGC
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/GIST.md
+++ b/wiki/cancer_types/GIST.md
@@ -1,6 +1,7 @@
 ---
 name: Gastrointestinal Stromal Tumor
 oncotree_code: GIST
+main_type: Gastrointestinal Stromal Tumor
 parent: SOFT_TISSUE
 tags: [sarcoma, gi]
 processed_by: crosslinker

--- a/wiki/cancer_types/HCC.md
+++ b/wiki/cancer_types/HCC.md
@@ -1,6 +1,7 @@
 ---
 name: Hepatocellular Carcinoma
 oncotree_code: HCC
+main_type: Hepatobiliary Cancer
 parent: LIVER
 tags: [liver, hepatobiliary]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/HGSOC.md
+++ b/wiki/cancer_types/HGSOC.md
@@ -1,6 +1,7 @@
 ---
-name: "High-Grade Serous Ovarian Cancer"
+name: High-Grade Serous Ovarian Cancer
 oncotree_code: HGSOC
+main_type: Ovarian Cancer
 parent: SOC
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/HNSC.md
+++ b/wiki/cancer_types/HNSC.md
@@ -1,6 +1,7 @@
 ---
 name: Head and Neck Squamous Cell Carcinoma
 oncotree_code: HNSC
+main_type: Head and Neck Cancer
 parent: HEAD_NECK
 tags: [head-neck, squamous, hpv, immunotherapy, radiation]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/IHCH.md
+++ b/wiki/cancer_types/IHCH.md
@@ -1,6 +1,7 @@
 ---
 name: Intrahepatic Cholangiocarcinoma
 oncotree_code: IHCH
+main_type: Hepatobiliary Cancer
 parent: CHOL
 tags: [biliary, hepatobiliary]
 processed_by: crosslinker

--- a/wiki/cancer_types/LCH.md
+++ b/wiki/cancer_types/LCH.md
@@ -1,11 +1,11 @@
 ---
 name: Langerhans Cell Histiocytosis
 oncotree_code: LCH
+main_type: Histiocytosis
 parent: HDCN
 tags: [histiocytosis, rare-cancers]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Histiocytosis
 ---
 
 # Langerhans Cell Histiocytosis (LCH)

--- a/wiki/cancer_types/LMS.md
+++ b/wiki/cancer_types/LMS.md
@@ -1,6 +1,7 @@
 ---
-name: "Leiomyosarcoma"
+name: Leiomyosarcoma
 oncotree_code: LMS
+main_type: Soft Tissue Sarcoma
 parent: SOFT_TISSUE
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/LUAD.md
+++ b/wiki/cancer_types/LUAD.md
@@ -1,11 +1,11 @@
 ---
 name: Lung Adenocarcinoma
 oncotree_code: LUAD
+main_type: Non-Small Cell Lung Cancer
 parent: NSCLC
 tags: [lung, nsclc]
 processed_by: crosslinker
 processed_at: 2026-04-11
-main_type: Non-Small Cell Lung Cancer
 ---
 
 # Lung Adenocarcinoma (LUAD)

--- a/wiki/cancer_types/LUSC.md
+++ b/wiki/cancer_types/LUSC.md
@@ -1,11 +1,11 @@
 ---
 name: Lung Squamous Cell Carcinoma
 oncotree_code: LUSC
+main_type: Non-Small Cell Lung Cancer
 parent: NSCLC
 tags: [lung, nsclc, squamous]
 processed_by: entity-page-writer
 processed_at: 2026-04-11
-main_type: Non-Small Cell Lung Cancer
 ---
 
 # Lung Squamous Cell Carcinoma (LUSC)

--- a/wiki/cancer_types/MBL.md
+++ b/wiki/cancer_types/MBL.md
@@ -1,11 +1,11 @@
 ---
 name: Medulloblastoma
 oncotree_code: MBL
+main_type: Embryonal Tumor
 parent: EMBT
 tags: [cns, embryonal, pediatric]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Embryonal Tumor
 ---
 
 # Medulloblastoma (MBL)

--- a/wiki/cancer_types/MEITL.md
+++ b/wiki/cancer_types/MEITL.md
@@ -1,11 +1,11 @@
 ---
 name: Monomorphic Epitheliotropic Intestinal T-Cell Lymphoma
 oncotree_code: MEITL
+main_type: Mature T and NK Neoplasms
 parent: MTNN
 tags: [lymphoma, t-cell, intestinal]
 processed_by: crosslinker
 processed_at: 2026-04-11
-main_type: Mature T and NK Neoplasms
 ---
 
 # Monomorphic Epitheliotropic Intestinal T-Cell Lymphoma (MEITL)

--- a/wiki/cancer_types/MEL.md
+++ b/wiki/cancer_types/MEL.md
@@ -1,6 +1,7 @@
 ---
 name: Melanoma
 oncotree_code: MEL
+main_type: Melanoma
 parent: SKIN
 tags: [melanoma, skin]
 processed_by: crosslinker

--- a/wiki/cancer_types/MFH.md
+++ b/wiki/cancer_types/MFH.md
@@ -1,6 +1,7 @@
 ---
 name: Undifferentiated Pleomorphic Sarcoma/Malignant Fibrous Histiocytoma/High-Grade Spindle Cell Sarcoma
 oncotree_code: MFH
+main_type: Soft Tissue Sarcoma
 parent: SOFT_TISSUE
 tags: [radiation-associated-sarcoma, soft-tissue-sarcoma]
 processed_by: crosslinker

--- a/wiki/cancer_types/MGCT.md
+++ b/wiki/cancer_types/MGCT.md
@@ -1,11 +1,11 @@
 ---
 name: Mixed Germ Cell Tumor
 oncotree_code: MGCT
+main_type: Germ Cell Tumor
 parent: NSGCT
 tags: [germ-cell, rare-cancers]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Germ Cell Tumor
 ---
 
 # Mixed Germ Cell Tumor (MGCT)

--- a/wiki/cancer_types/MNG.md
+++ b/wiki/cancer_types/MNG.md
@@ -1,6 +1,7 @@
 ---
-name: "Meningioma"
+name: Meningioma
 oncotree_code: MNG
+main_type: CNS Cancer
 parent: MNGT
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/MPNST.md
+++ b/wiki/cancer_types/MPNST.md
@@ -1,6 +1,7 @@
 ---
 name: Malignant Peripheral Nerve Sheath Tumor
 oncotree_code: MPNST
+main_type: Nerve Sheath Tumor
 parent: NST
 tags: [radiation-associated-sarcoma, nerve-sheath-tumor]
 processed_by: crosslinker

--- a/wiki/cancer_types/NBL.md
+++ b/wiki/cancer_types/NBL.md
@@ -1,6 +1,7 @@
 ---
 name: Neuroblastoma
 oncotree_code: NBL
+main_type: Peripheral Nervous System
 parent: PNS
 tags: [pediatric, neuroblastoma, radiation, intra-tumoral-heterogeneity, mibg]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/NSCLC.md
+++ b/wiki/cancer_types/NSCLC.md
@@ -1,11 +1,11 @@
 ---
 name: Non-Small Cell Lung Cancer
 oncotree_code: NSCLC
+main_type: Non-Small Cell Lung Cancer
 parent: LUNG
 tags: [lung, nsclc]
 processed_by: entity-page-writer
 processed_at: 2026-04-15
-main_type: Non-Small Cell Lung Cancer
 ---
 
 # Non-Small Cell Lung Cancer (NSCLC)

--- a/wiki/cancer_types/ODG.md
+++ b/wiki/cancer_types/ODG.md
@@ -1,6 +1,7 @@
 ---
 name: Oligodendroglioma
 oncotree_code: ODG
+main_type: Glioma
 parent: DIFG
 tags: [glioma, cns, IDH-mutant, 1p19q-codeleted]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/OGCT.md
+++ b/wiki/cancer_types/OGCT.md
@@ -1,11 +1,11 @@
 ---
 name: Ovarian Germ Cell Tumor
 oncotree_code: OGCT
+main_type: Germ Cell Tumor
 parent: OVARY
 tags: [germ-cell, ovarian, rare-cancers]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Germ Cell Tumor
 ---
 
 # Ovarian Germ Cell Tumor (OGCT)

--- a/wiki/cancer_types/OS.md
+++ b/wiki/cancer_types/OS.md
@@ -1,6 +1,7 @@
 ---
 name: Osteosarcoma
 oncotree_code: OS
+main_type: Bone Cancer
 parent: BONE
 tags: [radiation-associated-sarcoma, bone-tumor]
 processed_by: crosslinker

--- a/wiki/cancer_types/OVT.md
+++ b/wiki/cancer_types/OVT.md
@@ -1,6 +1,7 @@
 ---
-name: "Ovarian Epithelial Tumor"
+name: Ovarian Epithelial Tumor
 oncotree_code: OVT
+main_type: Ovarian Cancer
 parent: OVARY
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/PAAD.md
+++ b/wiki/cancer_types/PAAD.md
@@ -1,6 +1,7 @@
 ---
 name: Pancreatic Adenocarcinoma
 oncotree_code: PAAD
+main_type: Pancreatic Cancer
 parent: PANCREAS
 tags: [pancreas, kras-driven]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/PAST.md
+++ b/wiki/cancer_types/PAST.md
@@ -1,6 +1,7 @@
 ---
 name: Pilocytic Astrocytoma
 oncotree_code: PAST
+main_type: Glioma
 parent: ENCG
 tags: [glioma, cns, pediatric, low-grade]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/PCNSL.md
+++ b/wiki/cancer_types/PCNSL.md
@@ -1,10 +1,9 @@
 ---
 name: Primary CNS Lymphoma
 oncotree_code: PCNSL
+main_type: Mature B-Cell Neoplasms
 parent: DLBCLNOS
-tags:
-  - cns-lymphoma
-  - b-cell-lymphoma
+tags: [cns-lymphoma, b-cell-lymphoma]
 processed_by: crosslinker
 processed_at: 2026-04-10
 ---

--- a/wiki/cancer_types/PLMESO.md
+++ b/wiki/cancer_types/PLMESO.md
@@ -1,6 +1,7 @@
 ---
-name: "Pleural Mesothelioma"
+name: Pleural Mesothelioma
 oncotree_code: PLMESO
+main_type: Mesothelioma
 parent: PLEURA
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/PRAD.md
+++ b/wiki/cancer_types/PRAD.md
@@ -1,6 +1,7 @@
 ---
 name: Prostate Adenocarcinoma
 oncotree_code: PRAD
+main_type: Prostate Cancer
 parent: PROSTATE
 tags: [prostate]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/PRNE.md
+++ b/wiki/cancer_types/PRNE.md
@@ -1,6 +1,7 @@
 ---
-name: "Prostate Neuroendocrine Carcinoma"
+name: Prostate Neuroendocrine Carcinoma
 oncotree_code: PRNE
+main_type: Prostate Cancer
 parent: PROSTATE
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/PTAD.md
+++ b/wiki/cancer_types/PTAD.md
@@ -1,6 +1,7 @@
 ---
-name: "Pituitary Adenoma"
+name: Pituitary Adenoma
 oncotree_code: PTAD
+main_type: Sellar Tumor
 parent: SELT
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/PTCL.md
+++ b/wiki/cancer_types/PTCL.md
@@ -1,11 +1,11 @@
 ---
 name: Peripheral T-Cell lymphoma, NOS
 oncotree_code: PTCL
+main_type: Mature T and NK Neoplasms
 parent: MTNN
 tags: [lymphoma, t-cell]
 processed_by: crosslinker
 processed_at: 2026-04-11
-main_type: Mature T and NK Neoplasms
 ---
 
 # Peripheral T-Cell Lymphoma, NOS (PTCL)

--- a/wiki/cancer_types/READ.md
+++ b/wiki/cancer_types/READ.md
@@ -1,6 +1,7 @@
 ---
 name: Rectal Adenocarcinoma
 oncotree_code: READ
+main_type: Colorectal Cancer
 parent: COADREAD
 tags: [rectal, colorectal, immunotherapy]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/RMS.md
+++ b/wiki/cancer_types/RMS.md
@@ -1,11 +1,11 @@
 ---
 name: Rhabdomyosarcoma
 oncotree_code: RMS
+main_type: Soft Tissue Sarcoma
 parent: SOFT_TISSUE
 tags: [sarcoma, pediatric, rhabdomyosarcoma]
 processed_by: crosslinker
 processed_at: 2026-04-11
-main_type: Soft Tissue Sarcoma
 ---
 
 # Rhabdomyosarcoma (RMS)

--- a/wiki/cancer_types/SCLC.md
+++ b/wiki/cancer_types/SCLC.md
@@ -1,6 +1,7 @@
 ---
-name: "Small Cell Lung Cancer"
+name: Small Cell Lung Cancer
 oncotree_code: SCLC
+main_type: Small Cell Lung Cancer
 parent: LNET
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/SCRMS.md
+++ b/wiki/cancer_types/SCRMS.md
@@ -1,11 +1,11 @@
 ---
 name: Spindle Cell Rhabdomyosarcoma
 oncotree_code: SCRMS
+main_type: Soft Tissue Sarcoma
 parent: RMS
 tags: [sarcoma, rhabdomyosarcoma]
 processed_by: crosslinker
 processed_at: 2026-04-08
-main_type: Soft Tissue Sarcoma
 ---
 
 # Spindle Cell Rhabdomyosarcoma (SCRMS)

--- a/wiki/cancer_types/STAD.md
+++ b/wiki/cancer_types/STAD.md
@@ -1,6 +1,7 @@
 ---
-name: "Stomach Adenocarcinoma"
+name: Stomach Adenocarcinoma
 oncotree_code: STAD
+main_type: Esophagogastric Cancer
 parent: EGC
 tags: []
 processed_by: entity-page-writer

--- a/wiki/cancer_types/THAP.md
+++ b/wiki/cancer_types/THAP.md
@@ -1,6 +1,7 @@
 ---
-name: "Anaplastic Thyroid Cancer"
+name: Anaplastic Thyroid Cancer
 oncotree_code: THAP
+main_type: Thyroid Cancer
 parent: THYROID
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/THPA.md
+++ b/wiki/cancer_types/THPA.md
@@ -1,6 +1,7 @@
 ---
-name: "Papillary Thyroid Cancer"
+name: Papillary Thyroid Cancer
 oncotree_code: THPA
+main_type: Thyroid Cancer
 parent: WDTC
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/TLL.md
+++ b/wiki/cancer_types/TLL.md
@@ -1,6 +1,7 @@
 ---
 name: T-Lymphoblastic Leukemia/Lymphoma
 oncotree_code: TLL
+main_type: T-Lymphoblastic Leukemia/Lymphoma
 parent: LNM
 tags: [pediatric, leukemia]
 processed_by: entity-page-writer

--- a/wiki/cancer_types/UCEC.md
+++ b/wiki/cancer_types/UCEC.md
@@ -1,6 +1,7 @@
 ---
-name: "Endometrial Carcinoma"
+name: Endometrial Carcinoma
 oncotree_code: UCEC
+main_type: Endometrial Cancer
 parent: UTERUS
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/UCS.md
+++ b/wiki/cancer_types/UCS.md
@@ -1,6 +1,7 @@
 ---
-name: "Uterine Carcinosarcoma/Uterine Malignant Mixed Mullerian Tumor"
+name: Uterine Carcinosarcoma/Uterine Malignant Mixed Mullerian Tumor
 oncotree_code: UCS
+main_type: Endometrial Cancer
 parent: UCEC
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/ULMS.md
+++ b/wiki/cancer_types/ULMS.md
@@ -1,6 +1,7 @@
 ---
-name: "Uterine Leiomyosarcoma"
+name: Uterine Leiomyosarcoma
 oncotree_code: ULMS
+main_type: Uterine Sarcoma
 parent: USMT
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/USC.md
+++ b/wiki/cancer_types/USC.md
@@ -1,6 +1,7 @@
 ---
-name: "Uterine Serous Carcinoma/Uterine Papillary Serous Carcinoma"
+name: Uterine Serous Carcinoma/Uterine Papillary Serous Carcinoma
 oncotree_code: USC
+main_type: Endometrial Cancer
 parent: UCEC
 tags: []
 processed_by: crosslinker

--- a/wiki/cancer_types/UTUC.md
+++ b/wiki/cancer_types/UTUC.md
@@ -1,11 +1,9 @@
 ---
 name: Upper Tract Urothelial Carcinoma
 oncotree_code: UTUC
+main_type: Bladder Cancer
 parent: BLADDER
-tags:
-  - urothelial
-  - upper-tract
-  - fgfr3
+tags: [urothelial, upper-tract, fgfr3]
 processed_by: crosslinker
 processed_at: 2026-04-11
 ---


### PR DESCRIPTION
## Summary
- Adds `main_type` field to `schema/templates/cancer_type.md`, between `oncotree_code` and `parent`.
- Backfills `main_type` on every cancer_type page (74) from `schema/ontology/oncotree.json` (OncoTree `mainType`).
- Tightens `REQUIRED_FRONTMATTER["cancer_types"]` to require `oncotree_code` alongside `name`. All existing pages already carry both, so no regressions.

## Why
Gives the wiki a clinically meaningful grouping axis (e.g. all NSCLC pages → "Non-Small Cell Lung Cancer"), and closes a lint gap where a cancer_type page could ship without its OncoTree code.

## Test plan
- [x] `uv run pytest` — 49 passed
- [x] `uv run cbio-kb lint --wiki-dir wiki` — 1150 structural issues, 1 unverified term (matches main baseline; no new errors on cancer_type pages)
- [x] Spot-checked BRCA → Breast Cancer, LUAD → Non-Small Cell Lung Cancer, NSCLC → Non-Small Cell Lung Cancer, PAAD → Pancreatic Cancer, COAD → Colorectal Cancer
- [x] Verified no page lost its existing `parent:` value during reprocess

## Context
First of two PRs extracted from the abandoned `fix-quarto` working tree. The third item from that branch (empty `canonical_source` / `unverified` fields across 300+ pages) was intentionally dropped — the schema/CLAUDE.md contract does define those fields, but they deserve a scoped agent-populated rollout rather than a blanket empty-field migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)