### PR TITLE
fix(chat): retry fetch once on stale HTTP/2 socket

### DIFF
--- a/wiki/ask-chat.js
+++ b/wiki/ask-chat.js
@@ -142,61 +142,66 @@ function sendMessage(msg) {
     currentAssistantCard = null;
     currentAssistantText = '';
 
-    // Stream response
-    fetch(API_URL, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({message: msg, session_id: sessionId}),
-    }).then(function(response) {
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
+    // Stream response. Retry once on network errors (e.g. stale HTTP/2
+    // socket after Cloud Run scale-to-zero).
+    function doFetch(retries) {
+        fetch(API_URL, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({message: msg, session_id: sessionId}),
+        }).then(function(response) {
+            var reader = response.body.getReader();
+            var decoder = new TextDecoder();
+            var buffer = '';
 
-        let currentEvent = 'message';
-        let currentData = '';
+            var currentEvent = 'message';
+            var currentData = '';
 
-        function flushEvent() {
-            if (currentData) {
-                handleEvent(currentEvent, currentData, assistantDiv);
+            function flushEvent() {
+                if (currentData) {
+                    handleEvent(currentEvent, currentData, assistantDiv);
+                }
+                currentEvent = 'message';
+                currentData = '';
             }
-            currentEvent = 'message';
-            currentData = '';
-        }
 
-        function processChunk(result) {
-            if (result.done) {
-                flushEvent();
-                finishSending();
+            function processChunk(result) {
+                if (result.done) {
+                    flushEvent();
+                    finishSending();
+                    return;
+                }
+                buffer += decoder.decode(result.value, {stream: true});
+
+                var lines = buffer.split('\n');
+                buffer = lines.pop();
+
+                for (var i = 0; i < lines.length; i++) {
+                    var line = lines[i].replace(/\r$/, '');
+                    if (line === '') {
+                        flushEvent();
+                    } else if (line.startsWith('event:')) {
+                        currentEvent = line.slice(6).trim();
+                    } else if (line.startsWith('data:')) {
+                        currentData = line.slice(5).trim();
+                    }
+                }
+
+                messages.scrollTop = messages.scrollHeight;
+                return reader.read().then(processChunk);
+            }
+
+            return reader.read().then(processChunk);
+        }).catch(function(err) {
+            if (retries > 0) {
+                setTimeout(function() { doFetch(retries - 1); }, 500);
                 return;
             }
-            buffer += decoder.decode(result.value, {stream: true});
-
-            // Line-by-line parse: accumulate event/data until an empty line.
-            const lines = buffer.split('\n');
-            buffer = lines.pop(); // last (possibly incomplete) line
-
-            for (const rawLine of lines) {
-                const line = rawLine.replace(/\r$/, '');
-                if (line === '') {
-                    flushEvent();
-                } else if (line.startsWith('event:')) {
-                    currentEvent = line.slice(6).trim();
-                } else if (line.startsWith('data:')) {
-                    currentData = line.slice(5).trim();
-                } else if (line.startsWith(':')) {
-                    // comment / ping — ignore
-                }
-            }
-
-            messages.scrollTop = messages.scrollHeight;
-            return reader.read().then(processChunk);
-        }
-
-        return reader.read().then(processChunk);
-    }).catch(function(err) {
-        assistantDiv.textContent = 'Error: ' + err.message;
-        finishSending();
-    });
+            assistantDiv.textContent = 'Error: ' + err.message;
+            finishSending();
+        });
+    }
+    doFetch(1);
 }
 
 function handleEvent(eventType, data, assistantDiv) {


### PR DESCRIPTION
## Summary
- Wraps the SSE `fetch()` call in `doFetch(retries)` that retries once after 500ms on network errors
- Fixes `ERR_SOCKET_NOT_CONNECTED` users hit after Cloud Run scales to zero and Chrome holds a stale HTTP/2 socket

## Context
Chrome reuses HTTP/2 connections aggressively. When Cloud Run scales to zero mid-connection, Chrome's socket pool holds a dead reference. The next POST fails because Chrome won't auto-retry POSTs (non-idempotent). Previously required a hard refresh (`Cmd+Shift+R`) to recover.

## Test plan
- [ ] Deploy to Cloud Run, wait for scale-to-zero (~15 min idle)
- [ ] Send a chat message — should succeed transparently (retry fires once, second attempt gets a fresh socket)
- [ ] Normal operation unaffected — retry path only fires on network-level errors, not HTTP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)